### PR TITLE
Use target_compile_options and interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,23 @@
 cmake_minimum_required(VERSION 3.2)
 
+# Link this 'library' to use the following warnings
+add_library(project_warnings INTERFACE)
 if (MSVC)
-  add_compile_options(/W4)
+  target_compile_options(project_warnings INTERFACE /W4)
 else()
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  target_compile_options(project_warnings INTERFACE -Wall -Wextra -Wpedantic)
 endif()
 
 add_executable(intro main.cpp)
 target_compile_features(intro PRIVATE cxx_lambda_init_captures)
+target_link_libraries(intro PRIVATE project_warnings)
 
 
 enable_testing()
 
 add_executable(tester tester.cpp)
+target_link_libraries(tester PRIVATE project_warnings)
+
 add_test(Tester tester)
 
 


### PR DESCRIPTION
I prefer to use target_compile_options instead of add_compile_options (or any target_* instead of global commands) as it doesn't "pollute" the global environment. While I think of it of a good practice, there are some downsides too, and will try to enumerate both pros and cons here : 

# Pros
* Does not pollute the rest of the environment, hence allowing the integration of external dependencies (or existing code) using add_subdirectory
* In a more general way, flags should be set by target : 
    - sometimes you might want high level of warnings, perhaps even warning as error, sometimes you simply can't and need to disable some.
    - It might not make sense to add flags to all targets, for example (not the best one, but still) you might want to build without exceptions and use -fno-exceptions, but then what if you have a target that needs it in order to interface with some dependency ?
* Easier to track the origin of the flags
* Avoids people thinking that changing the global environment is the go-to thing, and then see more `set(CMAKE_CXX_FLAGS ...)`
* This one isn't really about our case (warnings) but still good to note : Takes advantage of the cmake buildsystem, if a flag is needed only for this target, use PRIVATE, if it is needed when linking the library, use PUBLIC/INTERFACE and cmake will take care of everything.

# Cons
* More verbose
* Harder to teach to beginners ?
* Can be forgotten on new targets
* One could argue you can still override add_compile_options using target_compile_options. While this is true for warnings, it is not the case for all compile options. Also makes it harder to track since those will be defined in two places.

# Alternatives
I tend to think more and more that cmake scripts should not set flags or anything that is unneeded for a target to be built. You want more warnings ? Change the cache ! You want coverage or sanitizers ? Use the cache or provide new build types ! Of course some of us want to enforce those, in which case I usually provide an option to disable those easily and give control back to the user. But then again, one can enforce it through CI and provide a commandline/shell script with all needed variables set.

Of course all the above is only my opinion, and I might stand corrected by someone who has more experience and insight on CMake than I do.  If so, please let me know by commenting this PR ! But having played with many buildsystems (make,cmake,jam,msbuild), I really think that non-mandatory compile options should either be set by the user or per-target.
Sorry for the rather long post but it helped me to write down some of the stuff I meant to for a while.
