### PR TITLE
Add qt gui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,13 @@ add_executable(intro main.cpp)
 target_compile_features(intro PRIVATE cxx_std_17)
 target_link_libraries(intro PRIVATE project_warnings --coverage)
 
+#qt
+find_package( Qt5Widgets REQUIRED )
+set( CMAKE_AUTOMOC ON )
+add_executable( helloQt qt/qtMain.cpp qt/HelloQt.cpp )
+target_link_libraries( helloQt Qt5::Widgets )
+target_compile_features( helloQt PUBLIC cxx_nullptr )
+
 enable_testing()
 
 add_executable(tester tester.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,13 @@ else()
                          -Wpedantic # warn if non-standard C++ is used
                          -Wconversion # warn on type conversions that may lose data
                          -Wsign-conversion # warn on sign conversions
-			 -Wmisleading-indentation # warn if identation implies blocks where blocks do not exist
-			 -Wduplicated-cond # warn if if / else chain has duplicated conditions
-			 -Wduplicated-branches # warn if if / else branches have duplicated code
+                         -Wmisleading-indentation # warn if identation implies blocks where blocks
+		                                  # do not exist
+                         -Wduplicated-cond # warn if if / else chain has duplicated conditions
+                         -Wduplicated-branches # warn if if / else branches have duplicated code
                          -Wlogical-op # warn about logical operations being used where bitwise were
                                       # probably wanted
-			 -Wnull-dereference # warn if a null dereference is detected
+                         -Wnull-dereference # warn if a null dereference is detected
                          -Wuseless-cast # warn if you perform a cast to the same type
                          -Wdouble-promotion # warn if float is implicit promoted to double
                          -Wformat=2 # warn on security issues around functions that format output
@@ -47,7 +48,7 @@ else()
 endif()
 
 add_executable(intro main.cpp)
-#target_compile_features(intro PRIVATE cxx_std_14)
+target_compile_features(intro PRIVATE cxx_std_17)
 target_link_libraries(intro PRIVATE project_warnings --coverage)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.8)
 
 option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" FALSE)
 
@@ -33,12 +33,12 @@ else()
                          -Wpedantic # warn if non-standard C++ is used
                          -Wconversion # warn on type conversions that may lose data
                          -Wsign-conversion # warn on sign conversions
-			 #-Wmisleading-indentation # warn if identation implies blocks where blocks do not exist
-			 #-Wduplicated-cond # warn if if / else chain has duplicated conditions
-			 #-Wduplicated-branches # warn if if / else branches have duplicated code
+			 -Wmisleading-indentation # warn if identation implies blocks where blocks do not exist
+			 -Wduplicated-cond # warn if if / else chain has duplicated conditions
+			 -Wduplicated-branches # warn if if / else branches have duplicated code
                          -Wlogical-op # warn about logical operations being used where bitwise were
                                       # probably wanted
-				      #-Wnull-dereference # warn if a null dereference is detected
+			 -Wnull-dereference # warn if a null dereference is detected
                          -Wuseless-cast # warn if you perform a cast to the same type
                          -Wdouble-promotion # warn if float is implicit promoted to double
                          -Wformat=2 # warn on security issues around functions that format output
@@ -47,7 +47,7 @@ else()
 endif()
 
 add_executable(intro main.cpp)
-#target_compile_features(intro PRIVATE cxx_std_14)
+target_compile_features(intro PRIVATE cxx_std_17)
 target_link_libraries(intro PRIVATE project_warnings --coverage)
 
 enable_testing()
@@ -95,7 +95,7 @@ target_link_libraries(test_imgui PRIVATE project_warnings imgui)
 target_include_directories(test_imgui PRIVATE ${SFML_INCLUDE_DIR})
 endif()
 
-## Nana
+# Nana
 if( DEFINED CPP_STARTER_USE_NANA )
 include(ExternalProject)
 ExternalProject_add(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
                          -Wconversion # warn on type conversions that may lose data
                          -Wsign-conversion # warn on sign conversions
                          -Wmisleading-indentation # warn if identation implies blocks where blocks
-		                                  # do not exist
+                                                  # do not exist
                          -Wduplicated-cond # warn if if / else chain has duplicated conditions
                          -Wduplicated-branches # warn if if / else branches have duplicated code
                          -Wlogical-op # warn about logical operations being used where bitwise were

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,13 @@ else()
                          -Wpedantic # warn if non-standard C++ is used
                          -Wconversion # warn on type conversions that may lose data
                          -Wsign-conversion # warn on sign conversions
-                         -Wmisleading-indentation # warn if identation implies blocks where blocks
+			 #-Wmisleading-indentation # warn if identation implies blocks where blocks
                                                   # do not exist
-                         -Wduplicated-cond # warn if if / else chain has duplicated conditions
-                         -Wduplicated-branches # warn if if / else branches have duplicated code
+						  #-Wduplicated-cond # warn if if / else chain has duplicated conditions
+						  #-Wduplicated-branches # warn if if / else branches have duplicated code
                          -Wlogical-op # warn about logical operations being used where bitwise were
                                       # probably wanted
-                         -Wnull-dereference # warn if a null dereference is detected
+				      #-Wnull-dereference # warn if a null dereference is detected
                          -Wuseless-cast # warn if you perform a cast to the same type
                          -Wdouble-promotion # warn if float is implicit promoted to double
                          -Wformat=2 # warn on security issues around functions that format output
@@ -48,15 +48,8 @@ else()
 endif()
 
 add_executable(intro main.cpp)
-target_compile_features(intro PRIVATE cxx_std_17)
+#target_compile_features(intro PRIVATE cxx_std_14)
 target_link_libraries(intro PRIVATE project_warnings --coverage)
-
-#qt
-find_package( Qt5Widgets REQUIRED )
-set( CMAKE_AUTOMOC ON )
-add_executable( helloQt qt/qtMain.cpp qt/HelloQt.cpp )
-target_link_libraries( helloQt Qt5::Widgets )
-target_compile_features( helloQt PUBLIC cxx_nullptr )
 
 enable_testing()
 
@@ -65,20 +58,36 @@ target_link_libraries(tester PRIVATE project_warnings --coverage)
 
 add_test(Tester tester)
 
+#qt
+if( DEFINED CPP_STARTER_USE_QT )
+message( "Using Qt" )
+find_package( Qt5Widgets REQUIRED )
+set( CMAKE_AUTOMOC ON )
+add_executable( helloQt qt/qtMain.cpp qt/HelloQt.cpp )
+#set_target_properties( helloQt PROPERTIES CMAKE_AUTOMOC ON )
+target_link_libraries( helloQt Qt5::Widgets )
+target_compile_features( helloQt PUBLIC cxx_nullptr cxx_lambdas )
+endif()
+
 #fltk test
+if( DEFINED CPP_STARTER_USE_FLTK )
 find_package(FLTK REQUIRED)
 add_executable(test_fltk fltk/test_fltk.cpp)
 target_link_libraries(test_fltk PRIVATE project_warnings ${FLTK_LIBRARIES})
 target_include_directories(test_fltk PRIVATE ${FLTK_INCLUDE_DIR})
+endif()
 
 # gtkmm test
+if( DEFINED CPP_STARTER_USE_GTKMM )
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
 add_executable(test_gtkmm gtkmm/main.cpp gtkmm/hello_world.cpp)
 target_link_libraries(test_gtkmm PRIVATE project_warnings ${GTKMM_LIBRARIES})
 target_include_directories(test_gtkmm PRIVATE ${GTKMM_INCLUDE_DIRS})
+endif()
 
 # imgui example
+if( DEFINED CPP_STARTER_USE_IMGUI )
 find_package(SFML COMPONENTS graphics window system)
 find_package(OpenGL)
 
@@ -90,8 +99,10 @@ target_link_libraries(imgui INTERFACE ${SFML_LIBRARIES} ${OPENGL_gl_LIBRARY})
 add_executable(test_imgui imgui/test.cpp)
 target_link_libraries(test_imgui PRIVATE project_warnings imgui)
 target_include_directories(test_imgui PRIVATE ${SFML_INCLUDE_DIR})
+endif()
 
-# Nana
+## Nana
+if( DEFINED CPP_STARTER_USE_NANA )
 include(ExternalProject)
 ExternalProject_add(
   Nana
@@ -106,5 +117,4 @@ ExternalProject_Get_Property(Nana SOURCE_DIR BINARY_DIR)
 add_executable(test_nana nana/main.cpp)
 target_include_directories(test_nana PRIVATE ${SOURCE_DIR}/include)
 target_link_libraries(test_nana PRIVATE ${BINARY_DIR}/libnana.so ${NANA_LINKS})
-
-
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,9 @@ else()
                          -Wpedantic # warn if non-standard C++ is used
                          -Wconversion # warn on type conversions that may lose data
                          -Wsign-conversion # warn on sign conversions
-			 #-Wmisleading-indentation # warn if identation implies blocks where blocks
-                                                  # do not exist
-						  #-Wduplicated-cond # warn if if / else chain has duplicated conditions
-						  #-Wduplicated-branches # warn if if / else branches have duplicated code
+			 #-Wmisleading-indentation # warn if identation implies blocks where blocks do not exist
+			 #-Wduplicated-cond # warn if if / else chain has duplicated conditions
+			 #-Wduplicated-branches # warn if if / else branches have duplicated code
                          -Wlogical-op # warn about logical operations being used where bitwise were
                                       # probably wanted
 				      #-Wnull-dereference # warn if a null dereference is detected
@@ -61,12 +60,7 @@ add_test(Tester tester)
 #qt
 if( DEFINED CPP_STARTER_USE_QT )
 message( "Using Qt" )
-find_package( Qt5Widgets REQUIRED )
-set( CMAKE_AUTOMOC ON )
-add_executable( helloQt qt/qtMain.cpp qt/HelloQt.cpp )
-#set_target_properties( helloQt PROPERTIES CMAKE_AUTOMOC ON )
-target_link_libraries( helloQt Qt5::Widgets )
-target_compile_features( helloQt PUBLIC cxx_nullptr cxx_lambdas )
+add_subdirectory(qt)
 endif()
 
 #fltk test

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -1,0 +1,6 @@
+find_package( Qt5Widgets REQUIRED )
+set( CMAKE_AUTOMOC ON )
+add_executable( helloQt qtMain.cpp HelloQt.cpp )
+#set_target_properties( helloQt PROPERTIES CMAKE_AUTOMOC ON )
+target_link_libraries( helloQt Qt5::Widgets )
+target_compile_features( helloQt PUBLIC cxx_nullptr cxx_lambdas )

--- a/qt/HelloQt.cpp
+++ b/qt/HelloQt.cpp
@@ -1,0 +1,45 @@
+#include "HelloQt.hpp"
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QDebug>
+
+HelloQt::HelloQt( QWidget* parent )
+	:QWidget( parent )
+{
+	// The memory management is not done explicitly but by using the parent relationship built into Qt
+	// The tr calls are not strictly neccesary, but it is all that is needed for future i18n.
+	auto mainLayout = new QVBoxLayout;
+	auto descriptiveLabel = new QLabel( tr("Descriptive") );
+	auto pushButton = new QPushButton( tr("Push me!") );
+	auto grouping = new QHBoxLayout;
+	auto directButton = new QPushButton( tr( "Directly!" ) );
+	auto fatal = new QPushButton( tr( "Don't push this button" ) );
+	// By adding the widgets to the main widget, they get parented and the parenting takes care of freeing the memory
+	grouping->addWidget( descriptiveLabel );
+	grouping->addWidget( pushButton );
+	mainLayout->addLayout( grouping );
+	mainLayout->addWidget( directButton );
+	mainLayout->addWidget( fatal );
+	setLayout( mainLayout );
+	// Signals and slots are use to simply define relationships between actions and effects
+	// By using this "new style" connect the types are checked at compile time to match
+	connect( pushButton, &QPushButton::clicked, this, &HelloQt::writeToDebug );
+	// Lambdas can also be used as can ordinary freestanding functions
+	connect( directButton, &QPushButton::clicked, [](){ qDebug() << tr( "I am in line" ); } );
+	// Most usefull signals and slots are already built into the framework.
+	connect( fatal, &QPushButton::clicked, this, &HelloQt::close );
+};
+
+HelloQt::~HelloQt()
+{
+	// Nothing to do here, the parent system makes sure that all the elements that are 
+	// parented to this is cleaned up
+}
+
+void HelloQt::writeToDebug( void )
+{
+	qDebug() << tr( "I don't know what I was supposed to debug here..." );
+}
+

--- a/qt/HelloQt.cpp
+++ b/qt/HelloQt.cpp
@@ -5,41 +5,43 @@
 #include <QLabel>
 #include <QDebug>
 
-HelloQt::HelloQt( QWidget* parent )
-	:QWidget( parent )
-{
-	// The memory management is not done explicitly but by using the parent relationship built into Qt
-	// The tr calls are not strictly neccesary, but it is all that is needed for future i18n.
-	auto mainLayout = new QVBoxLayout;
-	auto descriptiveLabel = new QLabel( tr("Descriptive") );
-	auto pushButton = new QPushButton( tr("Push me!") );
-	auto grouping = new QHBoxLayout;
-	auto directButton = new QPushButton( tr( "Directly!" ) );
-	auto fatal = new QPushButton( tr( "Don't push this button" ) );
-	// By adding the widgets to the main widget, they get parented and the parenting takes care of freeing the memory
-	grouping->addWidget( descriptiveLabel );
-	grouping->addWidget( pushButton );
-	mainLayout->addLayout( grouping );
-	mainLayout->addWidget( directButton );
-	mainLayout->addWidget( fatal );
-	setLayout( mainLayout );
-	// Signals and slots are use to simply define relationships between actions and effects
-	// By using this "new style" connect the types are checked at compile time to match
-	connect( pushButton, &QPushButton::clicked, this, &HelloQt::writeToDebug );
-	// Lambdas can also be used as can ordinary freestanding functions
-	connect( directButton, &QPushButton::clicked, [](){ qDebug() << tr( "I am in line" ); } );
-	// Most usefull signals and slots are already built into the framework.
-	connect( fatal, &QPushButton::clicked, this, &HelloQt::close );
+HelloQt::HelloQt(QWidget *parent) : QWidget(parent) {
+  // The memory management is not done explicitly but by using the parent
+  // relationship built into Qt
+  // The tr calls are not strictly neccesary, but it is all that is needed for
+  // future i18n.
+  auto mainLayout = new QVBoxLayout;
+  auto descriptiveLabel = new QLabel(tr("Descriptive"));
+  auto pushButton = new QPushButton(tr("Push me!"));
+  auto grouping = new QHBoxLayout;
+  auto directButton = new QPushButton(tr("Directly!"));
+  auto fatal = new QPushButton(tr("Don't push this button"));
+  // By adding the widgets to the main widget, they get parented and the
+  // parenting takes care of freeing the memory.
+  // Laying out in layouts makes the GUI automatically resize.
+  grouping->addWidget(descriptiveLabel);
+  grouping->addWidget(pushButton);
+  mainLayout->addLayout(grouping);
+  mainLayout->addWidget(directButton);
+  mainLayout->addWidget(fatal);
+  setLayout(mainLayout);
+  // Signals and slots are use to simply define relationships between actions
+  // and effects
+  // By using this "new style" connect the types are checked at compile time to
+  // match
+  connect(pushButton, &QPushButton::clicked, this, &HelloQt::writeToDebug);
+  // Lambdas can also be used as can ordinary freestanding functions
+  connect(directButton, &QPushButton::clicked,
+      []() { qDebug() << tr("I am in line"); });
+  // Most usefull signals and slots are already built into the framework.
+  connect(fatal, &QPushButton::clicked, this, &HelloQt::close); // could just use close
 };
 
-HelloQt::~HelloQt()
-{
-	// Nothing to do here, the parent system makes sure that all the elements that are 
-	// parented to this is cleaned up
+HelloQt::~HelloQt() {
+  // Nothing to do here, the parent system makes sure that all the elements that
+  // are parented to this is cleaned up
 }
 
-void HelloQt::writeToDebug( void )
-{
-	qDebug() << tr( "I don't know what I was supposed to debug here..." );
+void HelloQt::writeToDebug(void) {
+  qDebug() << tr("I don't know what I was supposed to debug here...");
 }
-

--- a/qt/HelloQt.hpp
+++ b/qt/HelloQt.hpp
@@ -1,0 +1,12 @@
+#include <QWidget>
+
+class HelloQt : public QWidget
+{
+	Q_OBJECT // Very Important, this is all the magic that is needed
+	public:
+		explicit HelloQt( QWidget* parent = nullptr );
+		~HelloQt();
+	private slots:
+		void writeToDebug( void );
+
+};

--- a/qt/HelloQt.hpp
+++ b/qt/HelloQt.hpp
@@ -2,11 +2,11 @@
 
 class HelloQt : public QWidget
 {
-	Q_OBJECT // Very Important, this is all the magic that is needed
-	public:
-		explicit HelloQt( QWidget* parent = nullptr );
-		~HelloQt();
-	private slots:
-		void writeToDebug( void );
+  Q_OBJECT // Very Important, this is all the magic that is needed
+  public:
+    explicit HelloQt(QWidget* parent = nullptr);
+    ~HelloQt();
+  private slots:
+    void writeToDebug();
 
 };

--- a/qt/qtMain.cpp
+++ b/qt/qtMain.cpp
@@ -1,12 +1,12 @@
 #include "HelloQt.hpp"
 #include <QApplication>
 
-int main( int argc, char* argv[] )
+int main(int argc, char* argv[])
 {
-	QApplication app( argc, argv );
-	HelloQt dialog;
-	dialog.show();
+  QApplication app(argc, argv);
+  HelloQt dialog;
+  dialog.show();
 
-	return app.exec(); // this runs the main event loop and sees to it that cleanup is done
+  return app.exec(); // this runs the main event loop and sees to it that cleanup is done
 }
 

--- a/qt/qtMain.cpp
+++ b/qt/qtMain.cpp
@@ -1,0 +1,12 @@
+#include "HelloQt.hpp"
+#include <QApplication>
+
+int main( int argc, char* argv[] )
+{
+	QApplication app( argc, argv );
+	HelloQt dialog;
+	dialog.show();
+
+	return app.exec(); // this runs the main event loop and sees to it that cleanup is done
+}
+


### PR DESCRIPTION
Updated using the recommendations from @alexallmont.
Remarks:
I haven't run clang-format on the code. The options that are in the .clang-format file are too new for my clang-format-3.5
You should really update your CMake Required version to 3.8, that is when cxx_std_17 makes it into target_compile_features, otherwise use the features you are actually using.
CMakeLists separated into subdirectory as suggested, I also took the liberty of adding some CMake define options so that I could actually run CMake without installing gtk.