### PR TITLE
Fix use of cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 
-option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" FALSE)
-option(CPP_STARTER_USE_QT "Enable compilation of QT sample" FALSE)
-option(CPP_STARTER_USE_FLTK "Enable compilation of FLTK sample" FALSE)
-option(CPP_STARTER_USE_GTKMM "Enable compilation of GTKMM sample" FALSE)
-option(CPP_STARTER_USE_IMGUI "Enable compilation of ImGui sample" FALSE)
-option(CPP_STARTER_USE_NANA "Enable compilation of Nana GUI sample" FALSE)
+option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" OFF)
+option(CPP_STARTER_USE_QT "Enable compilation of QT sample" OFF)
+option(CPP_STARTER_USE_FLTK "Enable compilation of FLTK sample" OFF)
+option(CPP_STARTER_USE_GTKMM "Enable compilation of GTKMM sample" OFF)
+option(CPP_STARTER_USE_IMGUI "Enable compilation of ImGui sample" OFF)
+option(CPP_STARTER_USE_NANA "Enable compilation of Nana GUI sample" OFF)
 
 # Link this 'library' to use the following warnings
 add_library(project_warnings INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,13 +63,13 @@ target_link_libraries(tester PRIVATE project_warnings --coverage)
 add_test(Tester tester)
 
 # qt
-if(DEFINED CPP_STARTER_USE_QT)
+if(CPP_STARTER_USE_QT)
   message("Using Qt")
   add_subdirectory(qt)
 endif()
 
 # fltk test
-if(DEFINED CPP_STARTER_USE_FLTK)
+if(CPP_STARTER_USE_FLTK)
   find_package(FLTK REQUIRED)
   add_executable(test_fltk fltk/test_fltk.cpp)
   target_link_libraries(test_fltk PRIVATE project_warnings ${FLTK_LIBRARIES})
@@ -77,7 +77,7 @@ if(DEFINED CPP_STARTER_USE_FLTK)
 endif()
 
 # gtkmm test
-if(DEFINED CPP_STARTER_USE_GTKMM)
+if(CPP_STARTER_USE_GTKMM)
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
   add_executable(test_gtkmm gtkmm/main.cpp gtkmm/hello_world.cpp)
@@ -86,7 +86,7 @@ if(DEFINED CPP_STARTER_USE_GTKMM)
 endif()
 
 # imgui example
-if(DEFINED CPP_STARTER_USE_IMGUI)
+if(CPP_STARTER_USE_IMGUI)
   find_package(SFML COMPONENTS graphics window system)
   find_package(OpenGL)
 
@@ -101,7 +101,7 @@ if(DEFINED CPP_STARTER_USE_IMGUI)
 endif()
 
 # Nana
-if(DEFINED CPP_STARTER_USE_NANA)
+if(CPP_STARTER_USE_NANA)
   include(ExternalProject)
   externalproject_add(Nana
                       GIT_REPOSITORY


### PR DESCRIPTION
The usage of options as it was implemented didn't work. Even though specifying that I only want to build the GTKMM GUI, CMake complained that it couldn't find some of the other toolkits.

Digging into the usage of options in the main CMakeLists.txt I found that they are not used properly.

This PR should fix those issues.