### PR TITLE
CMake: Use IMPORTED_TARGET for dependencies found via pkg_check_modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,10 +79,9 @@ endif()
 # gtkmm test
 if(DEFINED CPP_STARTER_USE_GTKMM)
   find_package(PkgConfig REQUIRED)
-  pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
+  pkg_check_modules(GTKMM REQUIRED IMPORTED_TARGET gtkmm-3.0)
   add_executable(test_gtkmm gtkmm/main.cpp gtkmm/hello_world.cpp)
-  target_link_libraries(test_gtkmm PRIVATE project_warnings ${GTKMM_LIBRARIES})
-  target_include_directories(test_gtkmm PRIVATE ${GTKMM_INCLUDE_DIRS})
+  target_link_libraries(test_gtkmm PRIVATE project_warnings PkgConfig::GTKMM)
 endif()
 
 # imgui example


### PR DESCRIPTION
In modern CMake it is preferable to link against other targets rather
than to add include paths and libraries of dependencies manually (see
https://www.youtube.com/watch?v=P4Rzd21U-1c)

Since CMake 3.6, the functions `pkg_check_modules` and
`pkg_search_module` of CMake module `FindPkgConfig.cmake` provide
`IMPORTED_TARGETS` to support this new paradigm.