### PR TITLE
Use gcc-7 instead of gcc-5 in .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-5
+      - g++-7
 
 script:
-  - CXX=/usr/bin/g++-5 CC=/usr/bin/gcc-5 cmake -D ENABLE_COVERAGE:BOOL=TRUE . 
+  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake -D ENABLE_COVERAGE:BOOL=TRUE . 
   - cmake --build . -- -j2 
   - ctest -j2
-  - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-5
+  - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-7
 
 
 


### PR DESCRIPTION
The last few builds of this project have failed, because the .travis.yml file specified gcc-5 as its compiler, although the CMakeLists.txt file specified several compiler warning flags that were not available in that compiler. Since gcc-7 supports these flags, I elected to use that version instead.