### PR TITLE
Add googletest and catch2 testing frameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-5
+      - g++-7
 
 script:
-  - CXX=/usr/bin/g++-5 CC=/usr/bin/gcc-5 cmake -D ENABLE_COVERAGE:BOOL=TRUE . 
+  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake -D ENABLE_COVERAGE:BOOL=TRUE . 
   - cmake --build . -- -j2 
   - ctest -j2
-  - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-5
+  - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-7
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,17 @@ addons:
     packages:
       - g++-7
 
+matrix:
+  include:
+    - os: linux
+      env:
+        - CMAKE_FLAGS=""
+    - os: linux
+      env:
+        - CMAKE_FLAGS="-DENABLE_COVERAGE:BOOL=TRUE -DCPP_STARTER_USE_GOOGLE_TEST=ON"
+
 script:
-  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake -D ENABLE_COVERAGE:BOOL=TRUE . 
+  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake ${CMAKE_FLAGS} .
   - cmake --build . -- -j2 
   - ctest -j2
   - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: trusty
-sudo: false
+dist: xenial
+sudo: true
 language: cpp
 
 addons:
@@ -13,10 +13,19 @@ matrix:
   include:
     - os: linux
       env:
-        - CMAKE_FLAGS=""
+        - CMAKE_FLAGS="-DENABLE_COVERAGE:BOOL=TRUE"
     - os: linux
       env:
         - CMAKE_FLAGS="-DENABLE_COVERAGE:BOOL=TRUE -DCPP_STARTER_USE_GOOGLE_TEST=ON"
+    - os: linux
+      before_install:
+        - git clone https://github.com/catchorg/Catch2.git
+        - cd Catch2
+        - cmake -Bbuild -H. -DBUILD_TESTING=OFF
+        - sudo env "PATH=$PATH" cmake --build build/ --target install
+        - cd ..
+      env:
+        - CMAKE_FLAGS="-DENABLE_COVERAGE:BOOL=TRUE -DCPP_STARTER_USE_CATCH2=ON"
 
 script:
   - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake ${CMAKE_FLAGS} .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option(CPP_STARTER_USE_FLTK "Enable compilation of FLTK sample" OFF)
 option(CPP_STARTER_USE_GTKMM "Enable compilation of GTKMM sample" OFF)
 option(CPP_STARTER_USE_IMGUI "Enable compilation of ImGui sample" OFF)
 option(CPP_STARTER_USE_NANA "Enable compilation of Nana GUI sample" OFF)
+option(CPP_STARTER_USE_GOOGLE_TEST "Enable Google Test Framework" OFF)
 
 # Link this 'library' to use the following warnings
 add_library(project_warnings INTERFACE)
@@ -58,9 +59,57 @@ target_link_libraries(intro PRIVATE project_warnings --coverage)
 
 enable_testing()
 
-add_executable(tester tester.cpp)
-target_link_libraries(tester PRIVATE project_warnings --coverage)
-add_test(Tester tester)
+if(CPP_STARTER_USE_GOOGLE_TEST)
+###########################################################
+# Google Test framework setup: as described at
+# https://github.com/google/googletest/blob/master/googletest/README.md
+
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+        ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+        EXCLUDE_FROM_ALL)
+
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+  include_directories("${gtest_SOURCE_DIR}/include")
+endif()
+
+# Now simply link against gtest or gtest_main as needed. Eg
+add_executable(gtester google_tests/gtest_main.cpp google_tests/GTestExample.cpp google_tests/GTestExample.h)
+target_link_libraries(gtester
+        PRIVATE project_warnings --coverage
+        PUBLIC gtest gtest_main)
+add_test(NAME GoogleTester COMMAND gtester)
+
+# End Google Test framework setup
+###########################################################
+else()   # CPP_STARTER_USE_GOOGLE_TEST
+  add_executable(tester tester.cpp)
+  target_link_libraries(tester PRIVATE project_warnings --coverage)
+  add_test(Tester tester)
+endif()  # CPP_STARTER_USE_GOOGLE_TEST
 
 # qt
 if(CPP_STARTER_USE_QT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(CPP_STARTER_USE_GTKMM "Enable compilation of GTKMM sample" OFF)
 option(CPP_STARTER_USE_IMGUI "Enable compilation of ImGui sample" OFF)
 option(CPP_STARTER_USE_NANA "Enable compilation of Nana GUI sample" OFF)
 option(CPP_STARTER_USE_GOOGLE_TEST "Enable Google Test Framework" OFF)
+option(CPP_STARTER_USE_CATCH2 "Enable Catch2 Framework" OFF)
 
 # Link this 'library' to use the following warnings
 add_library(project_warnings INTERFACE)
@@ -60,56 +61,70 @@ target_link_libraries(intro PRIVATE project_warnings --coverage)
 enable_testing()
 
 if(CPP_STARTER_USE_GOOGLE_TEST)
-###########################################################
-# Google Test framework setup: as described at
-# https://github.com/google/googletest/blob/master/googletest/README.md
+  ###########################################################
+  # Google Test framework setup: as described at
+  # https://github.com/google/googletest/blob/master/googletest/README.md
 
-# Download and unpack googletest at configure time
-configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-        RESULT_VARIABLE result
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
-endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-        RESULT_VARIABLE result
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "Build step for googletest failed: ${result}")
-endif()
+  # Download and unpack googletest at configure time
+  configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+          RESULT_VARIABLE result
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+          RESULT_VARIABLE result
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  endif()
 
-# Prevent overriding the parent project's compiler/linker
-# settings on Windows
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  # Prevent overriding the parent project's compiler/linker
+  # settings on Windows
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-# Add googletest directly to our build. This defines
-# the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-        ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
-        EXCLUDE_FROM_ALL)
+  # Add googletest directly to our build. This defines
+  # the gtest and gtest_main targets.
+  add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+          ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+          EXCLUDE_FROM_ALL)
 
-# The gtest/gtest_main targets carry header search path
-# dependencies automatically when using CMake 2.8.11 or
-# later. Otherwise we have to add them here ourselves.
-if (CMAKE_VERSION VERSION_LESS 2.8.11)
-  include_directories("${gtest_SOURCE_DIR}/include")
-endif()
+  # The gtest/gtest_main targets carry header search path
+  # dependencies automatically when using CMake 2.8.11 or
+  # later. Otherwise we have to add them here ourselves.
+  if (CMAKE_VERSION VERSION_LESS 2.8.11)
+    include_directories("${gtest_SOURCE_DIR}/include")
+  endif()
 
-# Now simply link against gtest or gtest_main as needed. Eg
-add_executable(gtester google_tests/gtest_main.cpp google_tests/GTestExample.cpp google_tests/GTestExample.h)
-target_link_libraries(gtester
-        PRIVATE project_warnings --coverage
-        PUBLIC gtest gtest_main)
-add_test(NAME GoogleTester COMMAND gtester)
+  # Now simply link against gtest or gtest_main as needed. Eg
+  add_executable(
+          gtester
+          google_tests/gtest_main.cpp
+          google_tests/GTestExample.cpp)
+  target_link_libraries(gtester
+          PRIVATE project_warnings --coverage
+          PUBLIC gtest gtest_main)
+  add_test(NAME GoogleTester COMMAND gtester)
 
-# End Google Test framework setup
-###########################################################
-else()   # CPP_STARTER_USE_GOOGLE_TEST
+elseif(CPP_STARTER_USE_CATCH2)
+  find_package(Catch2 REQUIRED)
+  add_executable(
+          catch_tester
+          catch_tests/catch_main.cpp
+          catch_tests/catch_test_example.cpp)
+  target_link_libraries(
+          catch_tester
+          PRIVATE project_warnings
+          PUBLIC Catch2::Catch2
+          --coverage)
+  add_test(NAME CatchTester COMMAND catch_tester)
+
+else()   # !CPP_STARTER_USE_GOOGLE_TEST && !CPP_STARTER_USE_CATCH2
   add_executable(tester tester.cpp)
   target_link_libraries(tester PRIVATE project_warnings --coverage)
-  add_test(Tester tester)
-endif()  # CPP_STARTER_USE_GOOGLE_TEST
+  add_test(NAME Tester COMMAND tester)
+endif()  # CPP_STARTER_USE_GOOGLE_TEST || CPP_STARTER_USE_CATCH2
 
 # qt
 if(CPP_STARTER_USE_QT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,10 +79,9 @@ endif()
 # gtkmm test
 if(CPP_STARTER_USE_GTKMM)
   find_package(PkgConfig REQUIRED)
-  pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
+  pkg_check_modules(GTKMM REQUIRED IMPORTED_TARGET gtkmm-3.0)
   add_executable(test_gtkmm gtkmm/main.cpp gtkmm/hello_world.cpp)
-  target_link_libraries(test_gtkmm PRIVATE project_warnings ${GTKMM_LIBRARIES})
-  target_include_directories(test_gtkmm PRIVATE ${GTKMM_INCLUDE_DIRS})
+  target_link_libraries(test_gtkmm PRIVATE project_warnings PkgConfig::GTKMM)
 endif()
 
 # imgui example

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,18 @@
+# As described by the documentation at
+# https://github.com/google/googletest/blob/master/googletest/README.md
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+        GIT_REPOSITORY    https://github.com/google/googletest.git
+        GIT_TAG           master
+        SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+        BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND     ""
+        INSTALL_COMMAND   ""
+        TEST_COMMAND      ""
+        )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,26 @@
 image:
   - Visual Studio 2017
 clone_folder: c:\projects\source
-build_script:
-- cmd: >-
-    mkdir build
 
-    cd build
-    
-    cmake c:\projects\source -G "Visual Studio 15"
-    
-    cmake --build . --config "Debug"
+environment:
+  matrix:
+    - CMAKE_FLAGS: "-DENABLE_COVERAGE:BOOL=TRUE"
+    - CMAKE_FLAGS: "-DENABLE_COVERAGE:BOOL=TRUE -DCPP_STARTER_USE_GOOGLE_TEST=ON"
+    - CMAKE_FLAGS: "-DENABLE_COVERAGE:BOOL=TRUE -DCPP_STARTER_USE_CATCH2=ON"
+
+before_build:
+  - git clone https://github.com/catchorg/Catch2.git
+  - cd Catch2
+  - cmake -Bbuild -H. -DBUILD_TESTING=OFF
+  - cmake --build build/ --target install
+  - cd ..
+
+build_script:
+  - mkdir build
+  - cd build
+  - cmake c:\projects\source -G "Visual Studio 15" %CMAKE_FLAGS%
+  - cmake --build . --config "Debug"
 
 test_script:
-- cmd: ctest -C Debug
+  - cmd: ctest -C Debug
 

--- a/catch_tests/catch_main.cpp
+++ b/catch_tests/catch_main.cpp
@@ -1,0 +1,5 @@
+// Let Catch provide main():
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>
+

--- a/catch_tests/catch_test_example.cpp
+++ b/catch_tests/catch_test_example.cpp
@@ -1,0 +1,6 @@
+#include <catch2/catch.hpp>
+
+//         Test Description,          Command Line Argument
+TEST_CASE( "The identity property is satisfied on addition", "[additive-identity]" ) {
+  REQUIRE( 1 + 0 == 1 );
+}

--- a/google_tests/GTestExample.cpp
+++ b/google_tests/GTestExample.cpp
@@ -1,0 +1,19 @@
+#include "GTestExample.h"
+
+TEST_F(GTestExample, AdditiveIdentity) {
+  EXPECT_EQ(1 + 0, 1);
+}
+
+TEST_F(GTestExample, Inequality) {
+  EXPECT_GT(1 + 1, 1);
+  EXPECT_LT(1, 1 + 1);
+  EXPECT_GE(1 + 1, 1);
+  EXPECT_LE(1, 1 + 1);
+}
+
+TEST_F(GTestExample, Tautology) {
+  EXPECT_TRUE(true);
+  EXPECT_FALSE(false);
+}
+
+

--- a/google_tests/GTestExample.h
+++ b/google_tests/GTestExample.h
@@ -1,0 +1,37 @@
+#ifndef CPP_STARTER_PROJECT_GTESTEXAMPLE_H
+#define CPP_STARTER_PROJECT_GTESTEXAMPLE_H
+
+#include "gtest/gtest.h"
+
+// Class GTestExample adapted from:
+// https://github.com/google/googletest/blob/master/googletest/docs/primer.md
+class GTestExample : public ::testing::Test {
+protected:
+  // You can remove any or all of the following functions if its body
+  // is empty.
+
+  GTestExample() {
+    // You can do set-up work for each test here.
+  }
+
+  ~GTestExample() override {
+    // You can do clean-up work that doesn't throw exceptions here.
+  }
+
+  // If the constructor and destructor are not enough for setting up
+  // and cleaning up each test, you can define the following methods:
+
+  void SetUp() override {
+    // Code here will be called immediately after the constructor (right
+    // before each test).
+  }
+
+  void TearDown() override {
+    // Code here will be called immediately after each test (right
+    // before the destructor).
+  }
+
+  // Objects declared here can be used by all tests in the test case for Foo.
+};
+
+#endif //CPP_STARTER_PROJECT_GTESTEXAMPLE_H

--- a/google_tests/gtest_main.cpp
+++ b/google_tests/gtest_main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+GTEST_API_ int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Hey, I don't know if you're at all interested in these, but I added support for the GoogleTest and Catch testing frameworks. There's a lot of boilerplate CMake code and travis.yml configuration involved in getting these frameworks to work, and I manage to screw it up all the time. This is useful for me personally, so I figure it might be useful for someone else too.