### PR TITLE
Fix compiler detection for AppleClang and compiler flags for catch_ma…

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -79,7 +79,7 @@ function(set_project_warnings project_name)
 
   if(MSVC)
     set(PROJECT_WARNINGS ${MSVC_WARNINGS})
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     set(PROJECT_WARNINGS ${CLANG_WARNINGS})
   else()
     set(PROJECT_WARNINGS ${GCC_WARNINGS})

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,7 +1,7 @@
 function(enable_sanitizers project_name)
 
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL
-                                             "Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                             "*Clang")
     option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
 
     if(ENABLE_COVERAGE)

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,7 +1,7 @@
 function(enable_sanitizers project_name)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
-                                             "*Clang")
+                                             ".*Clang")
     option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
 
     if(ENABLE_COVERAGE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 add_library(catch_main STATIC catch_main.cpp)
 target_link_libraries(catch_main PUBLIC CONAN_PKG::catch2)
+target_link_libraries(catch_main PRIVATE project_options)
 
 add_executable(tests tests.cpp)
 target_link_libraries(tests PRIVATE project_warnings project_options


### PR DESCRIPTION
Problems I found when I tried to build on OSX:

1. No `-std` flag was passed to the compiler when building `catch_main.cpp`
2. CMake was mistakenly using the sets of warnings defined for gcc. This is because the `CMAKE_CXX_COMPILER_ID` on OSX is actually `AppleClang` and the check for Clang in `CompilerWarnings.cmake` silently fails and fallsback to gcc.

also
3. conan gives an error in the configure phase as seen here: https://github.com/conan-io/cmake-conan/issues/159 . One solution that worked for me was to manually set 
```
export SDKROOT=$(xcodebuild -version -sdk macosx Path)
```
but I don't know if this is "good enough" solution or not.