### PR TITLE
Fix mis-detection of Clang on macOS

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -79,10 +79,10 @@ function(set_project_warnings project_name)
 
   if(MSVC)
     set(PROJECT_WARNINGS ${MSVC_WARNINGS})
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(PROJECT_WARNINGS ${CLANG_WARNINGS})
-  else()
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(PROJECT_WARNINGS ${GCC_WARNINGS})
+  else()
+    set(PROJECT_WARNINGS ${CLANG_WARNINGS})
   endif()
 
   target_compile_options(${project_name} INTERFACE ${PROJECT_WARNINGS})


### PR DESCRIPTION
It is better to test for "GNU" rather than "Clang" because on macOS that will resolve to "AppleClang" and the GNU warnings will be enabled and produce errors.