### PR TITLE
Add a working Mac CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,59 @@
-dist: bionic
-sudo: false
 language: cpp
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-snapshot
-      - doxygen
 
 install:
   - pip install --user conan cmake
 
+jobs:
+  include:
+    - os: osx
+      compiler: gcc
+      osx_image: xcode11.2    # includes gcc-9 by default
+      env:
+        # Conan is at: ${HOME}/Library/Python/2.7/bin: we need this in the path
+        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
+        - GCC_VER="9"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+      after_script:
+        - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
+    - os: osx
+      compiler: clang
+      osx_image: xcode11.2
+      env:
+        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
+        - MATRIX_EVAL=""
+    - os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - GCC_VER="9"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            # I couldn't get ${GCC_VER} in here successfully
+            - gcc-9
+            - g++-9
+            - doxygen
+      after_script:
+        - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
+    - os: linux
+      dist: bionic
+      compiler: clang
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+      addons: { apt: { packages: ['doxygen'] } }
+
+
+before_script:
+  - eval "${MATRIX_EVAL}"
 
 script:
-  - CXX=/usr/bin/gcc-10 CC=/usr/bin/g++-10 cmake -D ENABLE_COVERAGE:BOOL=TRUE . 
-  - cmake --build . -- -j2 
+  - cmake -D ENABLE_COVERAGE:BOOL=TRUE .
+  - cmake --build . -- -j2
   - ctest -j2
-  - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-5
 
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,19 @@
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
 clone_folder: c:\projects\source
 build_script:
 - cmd: >-
     mkdir build
 
     cd build
-    
-    cmake c:\projects\source -G "Visual Studio 15"
-    
-    cmake --build . --config "Debug"
+
+    pip install --user conan
+
+    set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Scripts
+
+    cmake c:\projects\source -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE:STRING=Release
+
+    cmake --build . --config "Release"
 
 test_script:
 - cmd: ctest -C Debug

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -79,7 +79,7 @@ function(set_project_warnings project_name)
 
   if(MSVC)
     set(PROJECT_WARNINGS ${MSVC_WARNINGS})
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     set(PROJECT_WARNINGS ${CLANG_WARNINGS})
   else()
     set(PROJECT_WARNINGS ${GCC_WARNINGS})

--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -18,7 +18,7 @@ conan_cmake_run(
   ${CONAN_EXTRA_REQUIRES}
   catch2/2.11.0
   docopt.cpp/0.6.2
-  fmt/6.0.0
+  fmt/6.1.2
   spdlog/1.5.0
   OPTIONS
   ${CONAN_EXTRA_OPTIONS}

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,7 +1,7 @@
 function(enable_sanitizers project_name)
 
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL
-                                             "Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                             ".*Clang")
     option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
 
     if(ENABLE_COVERAGE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 add_library(catch_main STATIC catch_main.cpp)
 target_link_libraries(catch_main PUBLIC CONAN_PKG::catch2)
+target_link_libraries(catch_main PRIVATE project_options)
 
 add_executable(tests tests.cpp)
 target_link_libraries(tests PRIVATE project_warnings project_options


### PR DESCRIPTION
There are a lot of people hanging out in the issues section that are having trouble getting this project to build properly on a Mac. For this reason, I think that it's really important to get continuous integration going on the Mac side. This will prevent a lot of headaches for Mac users.