### PR TITLE
.travis.yml compilers in CXX and CC were swapped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 
 
 script:
-  - CXX=/usr/bin/gcc-10 CC=/usr/bin/g++-10 cmake -D ENABLE_COVERAGE:BOOL=TRUE . 
+  - CXX=/usr/bin/g++-10 CC=/usr/bin/gcc-10 cmake -D ENABLE_COVERAGE:BOOL=TRUE . 
   - cmake --build . -- -j2 
   - ctest -j2
   - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-5


### PR DESCRIPTION
CXX should be g++, and CC should be gcc.
This was the case a month ago, but when they were updated to use gcc 10, they were swapped.