### PR TITLE
Update CompilerWarnings to include permissive-

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -37,6 +37,7 @@ function(set_project_warnings project_name)
       /w14906 # string literal cast to 'LPWSTR'
       /w14928 # illegal copy-initialization; more than one user-defined
               # conversion has been implicitly applied
+      /permissive- # standards conformance mode for MSVC compiler.
   )
 
   set(CLANG_WARNINGS


### PR DESCRIPTION
Added flag for standards conforming code in CompilerWarnings on Windows MSVC builds.