### PR TITLE
adding support for apple clang

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -79,7 +79,7 @@ function(set_project_warnings project_name)
 
   if(MSVC)
     set(PROJECT_WARNINGS ${MSVC_WARNINGS})
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
     set(PROJECT_WARNINGS ${CLANG_WARNINGS})
   else()
     set(PROJECT_WARNINGS ${GCC_WARNINGS})


### PR DESCRIPTION
It did not run mac but it gave errors that Clang does not support -Wmisleading-indentation, -Wduplicated-cond, etc  because cmake sets CMAKE_CXX_COMPILER_ID as "AppleClang" rather than "Clang" so I added the regex to it.