### PR TITLE
Ignore cppcheck unused function warning for fuzzing entry point

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -12,7 +12,7 @@ dangle_parens: false
 enum_char: .
 line_ending: unix
 line_width: 120
-max_subargs_per_line: 3
+max_pargs_hwrap: 3
 separate_ctrl_name_with_space: false
 separate_fn_name_with_space: false
 tab_size: 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ include(cmake/StaticAnalyzers.cmake)
 
 option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" OFF)
 option(ENABLE_TESTING "Enable Test Builds" ON)
+option(ENABLE_FUZZING "Enable Fuzzing Builds" ON)
 
 # Very basic PCH example
 option(ENABLE_PCH "Enable Precompiled Headers" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,53 +31,45 @@ option(ENABLE_TESTING "Enable Test Builds" ON)
 
 # Very basic PCH example
 option(ENABLE_PCH "Enable Precompiled Headers" OFF)
-if (ENABLE_PCH)
-  # This sets a global PCH parameter, each project will build its own PCH, which
-  # is a good idea if any #define's change
-  # 
-  # 
-  target_precompile_headers(project_options INTERFACE <vector> <string> <map> <utility>)
+if(ENABLE_PCH)
+  # This sets a global PCH parameter, each project will build its own PCH, which is a good idea if any #define's change
+  target_precompile_headers(
+    project_options
+    INTERFACE
+    <vector>
+    <string>
+    <map>
+    <utility>)
 endif()
 
-
-# Set up some extra Conan dependencies based on our needs
-# before loading Conan
+# Set up some extra Conan dependencies based on our needs before loading Conan
 set(CONAN_EXTRA_REQUIRES "")
 set(CONAN_EXTRA_OPTIONS "")
 
 if(CPP_STARTER_USE_IMGUI)
-  set(CONAN_EXTRA_REQUIRES ${CONAN_EXTRA_REQUIRES}
-                           imgui-sfml/2.1@bincrafters/stable)
+  set(CONAN_EXTRA_REQUIRES ${CONAN_EXTRA_REQUIRES} imgui-sfml/2.1@bincrafters/stable)
 
-  # set(CONAN_EXTRA_OPTIONS ${CONAN_EXTRA_OPTIONS} sfml:shared=False
-  # sfml:graphics=True sfml:audio=False sfml:window=True
-  # libalsa:disable_python=True)
+  # set(CONAN_EXTRA_OPTIONS ${CONAN_EXTRA_OPTIONS} sfml:shared=False sfml:graphics=True sfml:audio=False
+  # sfml:window=True libalsa:disable_python=True)
 endif()
 
 if(CPP_STARTER_USE_SDL)
-  set(CONAN_EXTRA_REQUIRES ${CONAN_EXTRA_REQUIRES}
-                           sdl2/2.0.10@bincrafters/stable)
+  set(CONAN_EXTRA_REQUIRES ${CONAN_EXTRA_REQUIRES} sdl2/2.0.10@bincrafters/stable)
   # set(CONAN_EXTRA_OPTIONS ${CONAN_EXTRA_OPTIONS} sdl2:wayland=True)
 endif()
-
 
 include(cmake/Conan.cmake)
 run_conan()
 
 if(ENABLE_TESTING)
   enable_testing()
-  message(
-    "Building Tests. Be sure to check out test/constexpr_tests for constexpr testing"
-  )
+  message("Building Tests. Be sure to check out test/constexpr_tests for constexpr testing")
   add_subdirectory(test)
 endif()
 
 if(ENABLE_FUZZING)
-  message(
-    "Building Fuzz Tests, using fuzzing sanitizer https://www.llvm.org/docs/LibFuzzer.html"
-  )
+  message("Building Fuzz Tests, using fuzzing sanitizer https://www.llvm.org/docs/LibFuzzer.html")
   add_subdirectory(fuzz_test)
 endif()
-
 
 add_subdirectory(src)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,79 +1,64 @@
 # from here:
 #
-# https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Avai
-# lable.md
+# https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
 
 function(set_project_warnings project_name)
   option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
 
   set(MSVC_WARNINGS
       /W4 # Baseline reasonable warnings
-      /w14242 # 'identfier': conversion from 'type1' to 'type1', possible loss
-              # of data
-      /w14254 # 'operator': conversion from 'type1:field_bits' to
-              # 'type2:field_bits', possible loss of data
-      /w14263 # 'function': member function does not override any base class
-              # virtual member function
-      /w14265 # 'classname': class has virtual functions, but destructor is not
-              # virtual instances of this class may not be destructed correctly
+      /w14242 # 'identfier': conversion from 'type1' to 'type1', possible loss of data
+      /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+      /w14263 # 'function': member function does not override any base class virtual member function
+      /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
+              # be destructed correctly
       /w14287 # 'operator': unsigned/negative constant mismatch
-      /we4289 # nonstandard extension used: 'variable': loop control variable
-              # declared in the for-loop is used outside the for-loop scope
+      /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
+              # the for-loop scope
       /w14296 # 'operator': expression is always 'boolean_value'
       /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
-      /w14545 # expression before comma evaluates to a function which is missing
-              # an argument list
+      /w14545 # expression before comma evaluates to a function which is missing an argument list
       /w14546 # function call before comma missing argument list
-      /w14547 # 'operator': operator before comma has no effect; expected
-              # operator with side-effect
-      /w14549 # 'operator': operator before comma has no effect; did you intend
-              # 'operator'?
+      /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
+      /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
       /w14555 # expression has no effect; expected expression with side- effect
       /w14619 # pragma warning: there is no warning number 'number'
       /w14640 # Enable warning on thread un-safe static member initialization
-      /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may
-              # cause unexpected runtime behavior.
+      /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
       /w14905 # wide string literal cast to 'LPSTR'
       /w14906 # string literal cast to 'LPWSTR'
-      /w14928 # illegal copy-initialization; more than one user-defined
-              # conversion has been implicitly applied
+      /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
   )
 
   set(CLANG_WARNINGS
       -Wall
       -Wextra # reasonable and standard
-      -Wshadow # warn the user if a variable declaration shadows one from a
-               # parent context
-      -Wnon-virtual-dtor # warn the user if a class with virtual functions has a
-                         # non-virtual destructor. This helps catch hard to
-                         # track down memory errors
+      -Wshadow # warn the user if a variable declaration shadows one from a parent context
+      -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps
+                         # catch hard to track down memory errors
       -Wold-style-cast # warn for c-style casts
       -Wcast-align # warn for potential performance problem casts
       -Wunused # warn on anything being unused
-      -Woverloaded-virtual # warn if you overload (not override) a virtual
-                           # function
+      -Woverloaded-virtual # warn if you overload (not override) a virtual function
       -Wpedantic # warn if non-standard C++ is used
       -Wconversion # warn on type conversions that may lose data
       -Wsign-conversion # warn on sign conversions
       -Wnull-dereference # warn if a null dereference is detected
       -Wdouble-promotion # warn if float is implicit promoted to double
-      -Wformat=2 # warn on security issues around functions that format output
-                 # (ie printf)
+      -Wformat=2 # warn on security issues around functions that format output (ie printf)
   )
 
-  if (WARNINGS_AS_ERRORS)
+  if(WARNINGS_AS_ERRORS)
     set(CLANG_WARNINGS ${CLANG_WARNINGS} -Werror)
     set(MSVC_WARNINGS ${MSVC_WARNINGS} /WX)
   endif()
 
   set(GCC_WARNINGS
       ${CLANG_WARNINGS}
-      -Wmisleading-indentation # warn if identation implies blocks where blocks
-                               # do not exist
+      -Wmisleading-indentation # warn if identation implies blocks where blocks do not exist
       -Wduplicated-cond # warn if if / else chain has duplicated conditions
       -Wduplicated-branches # warn if if / else branches have duplicated code
-      -Wlogical-op # warn about logical operations being used where bitwise were
-                   # probably wanted
+      -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
       -Wuseless-cast # warn if you perform a cast to the same type
   )
 

--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -1,29 +1,29 @@
 macro(run_conan)
-# Download automatically, you can also just copy the conan.cmake file
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-  message(
-    STATUS
-      "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-  file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.15/conan.cmake"
-       "${CMAKE_BINARY_DIR}/conan.cmake")
-endif()
+  # Download automatically, you can also just copy the conan.cmake file
+  if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+    message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.15/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake")
+  endif()
 
-include(${CMAKE_BINARY_DIR}/conan.cmake)
+  include(${CMAKE_BINARY_DIR}/conan.cmake)
 
-conan_add_remote(NAME bincrafters URL
-                 https://api.bintray.com/conan/bincrafters/public-conan)
+  conan_add_remote(
+    NAME
+    bincrafters
+    URL
+    https://api.bintray.com/conan/bincrafters/public-conan)
 
-conan_cmake_run(
-  REQUIRES
-  ${CONAN_EXTRA_REQUIRES}
-  catch2/2.11.0
-  docopt.cpp/0.6.2
-  fmt/6.0.0
-  spdlog/1.5.0
-  OPTIONS
-  ${CONAN_EXTRA_OPTIONS}
-  BASIC_SETUP
-  CMAKE_TARGETS # individual targets to link to
-  BUILD
-  missing)
+  conan_cmake_run(
+    REQUIRES
+    ${CONAN_EXTRA_REQUIRES}
+    catch2/2.11.0
+    docopt.cpp/0.6.2
+    fmt/6.0.0
+    spdlog/1.5.0
+    OPTIONS
+    ${CONAN_EXTRA_OPTIONS}
+    BASIC_SETUP
+    CMAKE_TARGETS # individual targets to link to
+    BUILD
+    missing)
 endmacro()

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,7 +1,6 @@
 function(enable_sanitizers project_name)
 
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL
-                                             "Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
 
     if(ENABLE_COVERAGE)
@@ -21,8 +20,7 @@ function(enable_sanitizers project_name)
       list(APPEND SANITIZERS "memory")
     endif()
 
-    option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
-           "Enable undefined behavior sanitizer" FALSE)
+    option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR "Enable undefined behavior sanitizer" FALSE)
     if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
       list(APPEND SANITIZERS "undefined")
     endif()
@@ -32,16 +30,21 @@ function(enable_sanitizers project_name)
       list(APPEND SANITIZERS "thread")
     endif()
 
-    list(JOIN SANITIZERS "," LIST_OF_SANITIZERS)
+    list(
+      JOIN
+      SANITIZERS
+      ","
+      LIST_OF_SANITIZERS)
 
   endif()
 
   if(LIST_OF_SANITIZERS)
-    if(NOT "${LIST_OF_SANITIZERS}" STREQUAL "")
-      target_compile_options(${project_name}
-                             INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
-      target_link_libraries(${project_name}
-                            INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+    if(NOT
+       "${LIST_OF_SANITIZERS}"
+       STREQUAL
+       "")
+      target_compile_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+      target_link_libraries(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
     endif()
   endif()
 

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -1,13 +1,17 @@
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(
-    STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+  message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
   set(CMAKE_BUILD_TYPE
       RelWithDebInfo
       CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui, ccmake
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
-                                               "MinSizeRel" "RelWithDebInfo")
+  set_property(
+    CACHE CMAKE_BUILD_TYPE
+    PROPERTY STRINGS
+             "Debug"
+             "Release"
+             "MinSizeRel"
+             "RelWithDebInfo")
 endif()
 
 find_program(CCACHE ccache)
@@ -18,22 +22,21 @@ else()
   message("ccache not found cannot use")
 endif()
 
-# Generate compile_commands.json to make it easier to work with clang based
-# tools
+# Generate compile_commands.json to make it easier to work with clang based tools
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-option(ENABLE_IPO
-       "Enable Iterprocedural Optimization, aka Link Time Optimization (LTO)"
-       OFF)
+option(ENABLE_IPO "Enable Iterprocedural Optimization, aka Link Time Optimization (LTO)" OFF)
 
 if(ENABLE_IPO)
   include(CheckIPOSupported)
-  check_ipo_supported(RESULT result OUTPUT output)
+  check_ipo_supported(
+    RESULT
+    result
+    OUTPUT
+    output)
   if(result)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
   else()
     message(SEND_ERROR "IPO is not supported: ${output}")
   endif()
 endif()
-
-

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -3,8 +3,13 @@ option(ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy" OFF)
 if(ENABLE_CPPCHECK)
   find_program(CPPCHECK cppcheck)
   if(CPPCHECK)
-    set(CMAKE_CXX_CPPCHECK ${CPPCHECK} --suppress=missingInclude --enable=all
-                           --inconclusive -i ${CMAKE_SOURCE_DIR}/imgui/lib)
+    set(CMAKE_CXX_CPPCHECK
+        ${CPPCHECK}
+        --suppress=missingInclude
+        --enable=all
+        --inconclusive
+        -i
+        ${CMAKE_SOURCE_DIR}/imgui/lib)
   else()
     message(SEND_ERROR "cppcheck requested but executable not found")
   endif()
@@ -18,5 +23,3 @@ if(ENABLE_CLANG_TIDY)
     message(SEND_ERROR "clang-tidy requested but executable not found")
   endif()
 endif()
-
-

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -7,6 +7,7 @@ if(ENABLE_CPPCHECK)
         ${CPPCHECK}
         --suppress=missingInclude
         --enable=all
+        --inline-suppr
         --inconclusive
         -i
         ${CMAKE_SOURCE_DIR}/imgui/lib)

--- a/fuzz_test/CMakeLists.txt
+++ b/fuzz_test/CMakeLists.txt
@@ -1,19 +1,19 @@
-# A fuzz test runs until it finds an error. This particular one is going to rely
-# on libFuzzer.
+# A fuzz test runs until it finds an error. This particular one is going to rely on libFuzzer.
 #
 
 add_executable(fuzz_tester fuzz_tester.cpp)
-target_link_libraries(fuzz_tester PRIVATE project_options project_warnings CONAN_PKG::fmt -coverage
-                                          -fsanitize=fuzzer,undefined,address)
-target_compile_options(fuzz_tester
-  PRIVATE -fsanitize=fuzzer,undefined,address)
+target_link_libraries(
+  fuzz_tester
+  PRIVATE project_options
+          project_warnings
+          CONAN_PKG::fmt
+          -coverage
+          -fsanitize=fuzzer,undefined,address)
+target_compile_options(fuzz_tester PRIVATE -fsanitize=fuzzer,undefined,address)
 
 # Allow short runs during automated testing to see if something new breaks
 set(FUZZ_RUNTIME
     10
-    CACHE STRING "Number of seconds to run fuzz tests during ctest run"
-)# Default of 10 seconds
+    CACHE STRING "Number of seconds to run fuzz tests during ctest run") # Default of 10 seconds
 
-
-add_test(NAME fuzz_tester_run COMMAND fuzz_tester
-                                  -max_total_time=${FUZZ_RUNTIME})
+add_test(NAME fuzz_tester_run COMMAND fuzz_tester -max_total_time=${FUZZ_RUNTIME})

--- a/fuzz_test/fuzz_tester.cpp
+++ b/fuzz_test/fuzz_tester.cpp
@@ -14,6 +14,7 @@
 }
 
 // Fuzzer that attempts to invoke undefined behavior for signed integer overflow
+// cppcheck-suppress unusedFunction symbolName=LLVMFuzzerTestOneInput
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
   fmt::print("Value sum: {}, len{}\n", sum_values(Data,Size), Size);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,5 +44,9 @@ endif()
 # Generic test that uses conan libs
 add_executable(intro main.cpp)
 target_link_libraries(
-  intro PRIVATE project_options project_warnings CONAN_PKG::docopt.cpp
-                CONAN_PKG::fmt CONAN_PKG::spdlog)
+  intro
+  PRIVATE project_options
+          project_warnings
+          CONAN_PKG::docopt.cpp
+          CONAN_PKG::fmt
+          CONAN_PKG::spdlog)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,18 +5,14 @@ else()
   include(${CONAN_CATCH2_ROOT}/lib/cmake/Catch2/Catch.cmake)
 endif()
 
-
 add_library(catch_main STATIC catch_main.cpp)
 target_link_libraries(catch_main PUBLIC CONAN_PKG::catch2)
 
 add_executable(tests tests.cpp)
-target_link_libraries(tests PRIVATE project_warnings project_options
-                                    catch_main)
+target_link_libraries(tests PRIVATE project_warnings project_options catch_main)
 
-
-# automatically discover tests that are defined in catch based test files you
-# can modify the unittests. TEST_PREFIX to whatever you want, or use different
-# for different binaries
+# automatically discover tests that are defined in catch based test files you can modify the unittests. TEST_PREFIX to
+# whatever you want, or use different for different binaries
 catch_discover_tests(
   tests
   TEST_PREFIX
@@ -28,8 +24,7 @@ catch_discover_tests(
 
 # Add a file containing a set of constexpr tests
 add_executable(constexpr_tests constexpr_tests.cpp)
-target_link_libraries(constexpr_tests PRIVATE project_options project_warnings
-                                              catch_main)
+target_link_libraries(constexpr_tests PRIVATE project_options project_warnings catch_main)
 
 catch_discover_tests(
   constexpr_tests
@@ -40,17 +35,11 @@ catch_discover_tests(
   --reporter=xml
   --out=constexpr.xml)
 
-# Disable the constexpr portion of the test, and build again this allows us to
-# have an executable that we can debug when things go wrong with the constexpr
-# testing
+# Disable the constexpr portion of the test, and build again this allows us to have an executable that we can debug when
+# things go wrong with the constexpr testing
 add_executable(relaxed_constexpr_tests constexpr_tests.cpp)
-target_link_libraries(
-  relaxed_constexpr_tests PRIVATE project_options project_warnings
-                                  catch_main)
-target_compile_definitions(
-  relaxed_constexpr_tests PRIVATE
-                                  -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
-
+target_link_libraries(relaxed_constexpr_tests PRIVATE project_options project_warnings catch_main)
+target_compile_definitions(relaxed_constexpr_tests PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
 
 catch_discover_tests(
   relaxed_constexpr_tests


### PR DESCRIPTION
cppcheck warning 'unusedFunction' for `LLVMFuzzerTestOneInput` should be ignored. In order to make this work the option `--inline-suppr` has to be added to the cppcheck invocation. While doing this I found that the ENABLE_FUZZING option was missing in ccmake and that the cmake files were not properly formatted according to `.cmake-format.yaml`. Further, cmake-format's option 'max-subargs_per_line' was removed in version 0.6.0.