### PR TITLE
Upgrade cmake-format

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -12,7 +12,7 @@ dangle_parens: false
 enum_char: .
 line_ending: unix
 line_width: 120
-max_subargs_per_line: 3
+max_pargs_hwrap: 3
 separate_ctrl_name_with_space: false
 separate_fn_name_with_space: false
 tab_size: 2


### PR DESCRIPTION
Since version 0.6.0 (Oct. 2019) cmake-format's `max-subargs_per_line`
option is removed. Similar behavior is achieved with `max_pargs_hwrap`.