### PR TITLE
ignore unusedFunction for LLVMFuzzerTestOneInput

### DIFF
--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -4,7 +4,7 @@ if(ENABLE_CPPCHECK)
   find_program(CPPCHECK cppcheck)
   if(CPPCHECK)
     set(CMAKE_CXX_CPPCHECK ${CPPCHECK} --suppress=missingInclude --enable=all
-                           --inconclusive -i ${CMAKE_SOURCE_DIR}/imgui/lib)
+                           --inline-suppr --inconclusive -i ${CMAKE_SOURCE_DIR}/imgui/lib)
   else()
     message(SEND_ERROR "cppcheck requested but executable not found")
   endif()

--- a/fuzz_test/fuzz_tester.cpp
+++ b/fuzz_test/fuzz_tester.cpp
@@ -14,6 +14,7 @@
 }
 
 // Fuzzer that attempts to invoke undefined behavior for signed integer overflow
+// cppcheck-suppress unusedFunction symbolName=LLVMFuzzerTestOneInput
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
   fmt::print("Value sum: {}, len{}\n", sum_values(Data,Size), Size);


### PR DESCRIPTION
Ignore cppcheck warning 'unusedFunction' for `LLVMFuzzerTestOneInput`.
To enable inline suppression the option `--inline-suppr` has to be added
to the cppcheck invocation (cmake/StaticAnalyzers.cmake).