### PR TITLE
Don't hardcode the target name when setting coverage check

### DIFF
--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -5,8 +5,8 @@ function(enable_sanitizers project_name)
     option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
 
     if(ENABLE_COVERAGE)
-      target_compile_options(project_options INTERFACE --coverage -O0 -g)
-      target_link_libraries(project_options INTERFACE --coverage)
+      target_compile_options(${project_name} INTERFACE --coverage -O0 -g)
+      target_link_libraries(${project_name} INTERFACE --coverage)
     endif()
 
     set(SANITIZERS "")


### PR DESCRIPTION
The function param is used when setting sanitizers but not when setting coverage check.