### PR TITLE
Fix spdlog dependency warning

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -18,7 +18,7 @@ conan_cmake_run(
   ${CONAN_EXTRA_REQUIRES}
   catch2/2.11.0
   docopt.cpp/0.6.2
-  fmt/6.1.2
+  fmt/6.2.0
   spdlog/1.5.0
   OPTIONS
   ${CONAN_EXTRA_OPTIONS}


### PR DESCRIPTION
spdlog 1.5 and 1.6 now require fmt 6.2.0, as of this commit:
https://github.com/conan-io/conan-center-index/pull/1651/commits/c19230f8ad6ae31a3699c4a66d90e29bad502ecb