### PR TITLE
Add more ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
                        -D ENABLE_SANITIZER_MEMORY:BOOL=ON \
                        -D ENABLE_SANITIZER_THREAD:BOOL=ON \
                        -D ENABLE_SANITIZER_UNDEFINED_BEHAVIOR:BOOL=ON"
-      install:
+      before_install:
         - brew install cppcheck
 
     - os: linux     # GCC-7 - Codecov build
@@ -161,7 +161,7 @@ jobs:
                        -D ENABLE_SANITIZER_MEMORY:BOOL=ON \
                        -D ENABLE_SANITIZER_THREAD:BOOL=ON \
                        -D ENABLE_SANITIZER_UNDEFINED_BEHAVIOR:BOOL=ON"
-      install:
+      before_install:
         - eval "${MATRIX_EVAL}"
         - git clone https://github.com/include-what-you-use/include-what-you-use.git
         - cd include-what-you-use && git checkout "clang_${CLANG_SEMVER}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,8 @@ jobs:
                        -D ENABLE_SANITIZER_MEMORY:BOOL=ON \
                        -D ENABLE_SANITIZER_THREAD:BOOL=ON \
                        -D ENABLE_SANITIZER_UNDEFINED_BEHAVIOR:BOOL=ON"
-      before_install:
+      before_script:
+        # Build IWYU: dependent on installing cmake in `install` step
         - eval "${MATRIX_EVAL}"
         - git clone https://github.com/include-what-you-use/include-what-you-use.git
         - cd include-what-you-use && git checkout "clang_${CLANG_SEMVER}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,69 @@ jobs:
         - sudo apt-get -qq update
         - sudo apt-get -y install clang-10
 
+    # Try many of the cmake options
+    # We can't do every combination of options, so we will try for a reasonable subset
+    - os: linux  # Clang-9 sanitize-all-the-things build
+      dist: bionic
+      compiler: clang
+      addons: { apt: { packages: ['clang-9', 'llvm-9-dev', 'libclang-9-dev'] } }
+      env:
+        - CLANG_VER="9"
+        - CLANG_SEMVER="9.0"
+        - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
+        - CONFIG_OPTS="-D ENABLE_INCLUDE_WHAT_YOU_USE:BOOL=ON \
+                       -D ENABLE_CLANG_TIDY:BOOL=ON \
+                       -D ENABLE_CPPCHECK:BOOL=ON \
+                       -D ENABLE_SANITIZER_ADDRESS:BOOL=ON \
+                       -D ENABLE_SANITIZER_MEMORY:BOOL=ON \
+                       -D ENABLE_SANITIZER_THREAD:BOOL=ON \
+                       -D ENABLE_SANITIZER_UNDEFINED_BEHAVIOR:BOOL=ON"
+      install:
+        - eval "${MATRIX_EVAL}"
+        - git clone https://github.com/include-what-you-use/include-what-you-use.git
+        - cd include-what-you-use && git checkout "clang_${CLANG_SEMVER}"
+        - mkdir build && cd build
+        - cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-${CLANG_VER} -DCMAKE_INSTALL_PREFIX=./ ..
+
+    - os: linux  # GCC-9 sanitize-all-the-things build, minus IWYU
+      dist: bionic
+      compiler: gcc
+      addons: { apt: { sources: ['ubuntu-toolchain-r-test'],
+                       packages: ['cppcheck', 'gcc-9', 'g++-9'] } }
+      env:
+        - GCC_VER="9"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+        - CONFIG_OPTS="-D ENABLE_CLANG_TIDY:BOOL=ON \
+                       -D ENABLE_CPPCHECK:BOOL=ON \
+                       -D ENABLE_SANITIZER_ADDRESS:BOOL=ON \
+                       -D ENABLE_SANITIZER_MEMORY:BOOL=ON \
+                       -D ENABLE_SANITIZER_THREAD:BOOL=ON \
+                       -D ENABLE_SANITIZER_UNDEFINED_BEHAVIOR:BOOL=ON"
+
+    - os: linux     # unity build GCC-7
+      dist: bionic
+      compiler: gcc
+      env:
+        - GCC_VER="7"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+        - CONFIG_OPTS="-D ENABLE_UNITY:BOOL=ON"
+
+    - os: linux     # pch build GCC-7
+      dist: bionic
+      compiler: gcc
+      env:
+        - GCC_VER="7"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+        - CONFIG_OPTS="-D ENABLE_PCH:BOOL=ON"
+
+    - os: linux     # ipo build GCC-7
+      dist: bionic
+      compiler: gcc
+      env:
+        - GCC_VER="7"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+        - CONFIG_OPTS="-D ENABLE_IPO:BOOL=ON"
+
 before_script:
   # Set CC and CXX
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,36 +10,86 @@ jobs:
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
       after_script:
         - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
+
     - os: osx
       compiler: clang
       osx_image: xcode11.2
       env:
         - MATRIX_EVAL=""
-    - os: linux
+
+    - os: linux     # GCC-7 - Codecov build
       dist: bionic
       compiler: gcc
+      env:
+        - GCC_VER="7"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+        - CONFIG_OPTS="-D ENABLE_COVERAGE:BOOL=TRUE"
+      after_script:
+        - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
+
+    - os: linux     # GCC-8 build
+      dist: bionic
+      compiler: gcc
+      addons: { apt: { packages: ['gcc-8', 'g++-8', 'doxygen'] } }
+      env:
+        - GCC_VER="8"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+
+    - os: linux     # GCC-9 build
+      dist: bionic
+      compiler: gcc
+      addons: { apt: { sources: ['ubuntu-toolchain-r-test'],
+                       packages: ['gcc-9', 'g++-9', 'doxygen'] } }
       env:
         - GCC_VER="9"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
 
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            # I couldn't get ${GCC_VER} in here successfully
-            - gcc-9
-            - g++-9
-            - doxygen
-      after_script:
-        - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
-    - os: linux
+    - os: linux     # GCC-10 build
+      dist: bionic
+      compiler: gcc
+      addons: { apt: { sources: ['ubuntu-toolchain-r-test'],
+                       packages: ['gcc-10', 'g++-10', 'doxygen'] } }
+      env:
+        - GCC_VER="10"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+
+    - os: linux     # Clang-6 build
       dist: bionic
       compiler: clang
+      addons: { apt: { packages: ['clang-6.0', 'doxygen'] } }
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
-      addons: { apt: { packages: ['doxygen'] } }
+        - CLANG_SEMVER="6.0"
+        - MATRIX_EVAL="CC=clang-${CLANG_SEMVER} && CXX=clang++-${CLANG_SEMVER}"
 
+    - os: linux     # Clang-8 build
+      dist: bionic
+      compiler: clang
+      addons: { apt: { packages: ['clang-8', 'doxygen'] } }
+      env:
+        - CLANG_VER="8"
+        - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
+
+    - os: linux     # Clang-9 build
+      dist: bionic
+      compiler: clang
+      addons: { apt: { packages: ['clang-9', 'doxygen'] } }
+      env:
+        - CLANG_VER="9"
+        - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
+
+    - os: linux     # Clang-10 build
+      dist: bionic
+      compiler: clang
+      addons: { apt: { packages: ['doxygen'] } }
+      env:
+        - CLANG_VER="10"
+        - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
+      before_install:   # Add sources disallowed by travis-ci
+        # Add LLVM repo and GPG key so we can install clang-10
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
+        - sudo apt-get -qq update
+        - sudo apt-get -y install clang-10
 
 before_script:
   # Set CC and CXX
@@ -62,7 +112,7 @@ before_script:
 
 
 script:
-  - cmake -D ENABLE_COVERAGE:BOOL=TRUE .
+  - cmake "${CONFIG_OPTS}" .
   - cmake --build . -- -j2
   - ctest -j2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: cpp
 
-install:
-  - pip install --user conan cmake
-
 jobs:
   include:
     - os: osx
       compiler: gcc
       osx_image: xcode11.2    # includes gcc-9 by default
       env:
-        # Conan is at: ${HOME}/Library/Python/2.7/bin: we need this in the path
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - GCC_VER="9"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
       after_script:
@@ -19,7 +14,6 @@ jobs:
       compiler: clang
       osx_image: xcode11.2
       env:
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - MATRIX_EVAL=""
     - os: linux
       dist: bionic
@@ -48,7 +42,24 @@ jobs:
 
 
 before_script:
+  # Set CC and CXX
   - eval "${MATRIX_EVAL}"
+
+  # Set default version of Python to 3: works the same way on Mac and Linux
+  - pip install virtualenv
+  - virtualenv -p python3 ~/venv
+  - source ~/venv/bin/activate
+
+  # Fail if we are using the wrong Python
+  - python --version | grep -iE 'python\s*3'
+  - pip    --version | grep -iE 'python\s*3'
+
+  # Install Conan using Python 3.
+  - pip install conan cmake
+
+  # Fail if we can't run Conan.
+  - conan --version
+
 
 script:
   - cmake -D ENABLE_COVERAGE:BOOL=TRUE .

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,6 +167,7 @@ jobs:
         - cd include-what-you-use && git checkout "clang_${CLANG_SEMVER}"
         - mkdir build && cd build
         - cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-${CLANG_VER} -DCMAKE_INSTALL_PREFIX=./ ..
+        - cd ../..  # Get out of IWYU
 
     - os: linux  # GCC-9 sanitize-all-the-things build, minus IWYU
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,60 @@ language: cpp
 
 jobs:
   include:
-    - os: osx
+    - os: osx       # 10.15.4 - gcc-9
       compiler: gcc
-      osx_image: xcode11.2    # includes gcc-9 by default
+      osx_image: xcode11.4
       env:
+        - MACOSX_DEPLOYMENT_TARGET=10.15
         - GCC_VER="9"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
-      after_script:
-        - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
 
-    - os: osx
-      compiler: clang
-      osx_image: xcode11.2
+    - os: osx       # 10.14.6 - gcc-9
+      compiler: gcc
+      osx_image: xcode11.3
       env:
-        - MATRIX_EVAL=""
+        - MACOSX_DEPLOYMENT_TARGET=10.14
+        - GCC_VER="9"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
+
+    - os: osx       # 10.13 - gcc-9
+      compiler: gcc
+      osx_image: xcode10.1
+      env:
+        - MACOSX_DEPLOYMENT_TARGET=10.13
+        - GCC_VER="9"
+        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}" #brew install gcc${GCC_VER} &&
+
+    - os: osx       # 10.15.4 - clang
+      compiler: clang
+      osx_image: xcode11.4
+      env:
+        - MACOSX_DEPLOYMENT_TARGET=10.15
+
+    - os: osx       # 10.14.6 - clang
+      compiler: clang
+      osx_image: xcode11.3
+      env:
+        - MACOSX_DEPLOYMENT_TARGET=10.14
+
+    - os: osx       # 10.13 - clang
+      compiler: clang
+      osx_image: xcode10.1
+      env:
+        - MACOSX_DEPLOYMENT_TARGET=10.13
+
+    - os: osx       # 10.15.4 - clang sanitize-all-the-things build
+      compiler: clang
+      osx_image: xcode11.4
+      env:
+        - MACOSX_DEPLOYMENT_TARGET=10.15
+        - CONFIG_OPTS="-D ENABLE_CPPCHECK:BOOL=ON \
+                       -D ENABLE_SANITIZER_ADDRESS:BOOL=ON \
+                       -D ENABLE_SANITIZER_MEMORY:BOOL=ON \
+                       -D ENABLE_SANITIZER_THREAD:BOOL=ON \
+                       -D ENABLE_SANITIZER_UNDEFINED_BEHAVIOR:BOOL=ON"
+      install:
+        - brew install cppcheck
 
     - os: linux     # GCC-7 - Codecov build
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,6 @@ jobs:
       compiler: gcc
       addons: { apt: { packages: ['gcc-8', 'g++-8', 'doxygen', 'python3-pip'] } }
       env:
-        - MATRIX_EVAL=""
-    - os: linux
         - GCC_VER="8"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
 
@@ -174,7 +172,7 @@ jobs:
       dist: bionic
       compiler: gcc
       addons: { apt: { sources: ['ubuntu-toolchain-r-test'],
-                       packages: ['cppcheck', 'gcc-9', 'g++-9'] } }
+                       packages: ['cppcheck', 'gcc-9', 'g++-9', 'python3-pip'] } }
       env:
         - GCC_VER="9"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
@@ -188,6 +186,7 @@ jobs:
     - os: linux     # unity build GCC-7
       dist: bionic
       compiler: gcc
+      addons: { apt: { packages: ['python3-pip'] } }
       env:
         - GCC_VER="7"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
@@ -196,6 +195,7 @@ jobs:
     - os: linux     # pch build GCC-7
       dist: bionic
       compiler: gcc
+      addons: { apt: { packages: ['python3-pip'] } }
       env:
         - GCC_VER="7"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
@@ -204,6 +204,7 @@ jobs:
     - os: linux     # ipo build GCC-7
       dist: bionic
       compiler: gcc
+      addons: { apt: { packages: ['python3-pip'] } }
       env:
         - GCC_VER="7"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ frameworks (fltk, gtkmm, imgui, etc.), you can remove them with `git rm`:
 
     $ git rm -r src/<unnecessary_framework>
 
+### Remove CI builds you're not going to use
+If you know that you need to use certain C++ features that are not supported by
+a particular version of clang or gcc, you can go into the `.travis.yml` file
+and remove builds that you know are not going to work. By default, this project
+spawns ~20 different CI builds; you almost certainly will not need all of them.
+
 ## Dependencies
 
 ### Necessary Dependencies


### PR DESCRIPTION
This PR adds several extra CI builds for Mac and Linux.

I have added several basic builds to test the following: 
* gcc 7-10 and clang 6&8-10 on Ubuntu 18 (for basic compiler compatibility)
* gcc-9 and apple-clang-11 on Mac OS 10.13, 10.14, and 10.15 (for OSX compatibility)
* A very small subset of the CMake options this project offers, on clang-9 and gcc-9 on Ubuntu 18

I did not go very far with regard to testing different combinations of the CMake options. There are 2^n possible ways to choose these options; complete coverage would be absurd.

Similarly, there's a combinatorial explosion of different possible OS/compiler setups to use, and I'm not going to try for complete coverage there either.

I have noticed that the more CI builds you attempt at once, the higher the chance that a few of them will fail due to package manager timeouts. At this stage, I have to re-trigger several builds manually before they all pass.

I feel that several (if not all) of these CI builds are necessary, just so we know what environments this project does and does not work in. However, I'm not convinced that these extra builds are useful to our users. I would expect most users to rip out most of these builds as soon as they begin their projects.

I am posting this as a draft PR because I need feedback: This is definitely not ready to merge.