### PR TITLE
Fix build error on code page 949

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
   endif()
 endif()
 
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 # Link this 'library' to use the warnings specified in CompilerWarnings.cmake
 add_library(project_warnings INTERFACE)
 


### PR DESCRIPTION
When I built without making any changes to this project, I found the following error.

```powershell
[main] Building folder: cpp_starter_project 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/lab/cpp_starter_project/build --config Debug --target ALL_BUILD -- /maxcpucount:14
[build] Microsoft (R) Build Engine version 16.5.0+d4cbfca49 for .NET Framework
[build] Copyright (C) Microsoft Corporation. All rights reserved.
[build] 
[build]   Checking Build System
[build]   Building Custom Rule C:/lab/cpp_starter_project/test/CMakeLists.txt
[build]   Building Custom Rule C:/lab/cpp_starter_project/src/CMakeLists.txt
[build]   catch_main.cpp
[build]   main.cpp
[build] C:\Users\PC\.conan\data\fmt\6.2.0\_\_\package\9ffec4a59d60a2ccf636e06ba57253e21417f01b\include\fmt/core.h(327,35): error C2220: the following warning is treated as an error [C:\lab\cpp_starter_project\build\src\intro.vcxproj]
[build] C:\Users\PC\.conan\data\fmt\6.2.0\_\_\package\9ffec4a59d60a2ccf636e06ba57253e21417f01b\include\fmt/core.h(327,35): warning C4566: character represented by universal-character-name '\u00B5' cannot be represented in the current code page (949) [C:\lab\cpp_starter_project\build\src\intro.vcxproj]
[build] C:\Users\PC\.conan\data\spdlog\1.5.0\_\_\package\cf72f4f3a71ff1fe5381d0f0ebe068c867c28045\include\spdlog/details/circular_q.h(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (949). Save the file in Unicode format to prevent data loss [C:\lab\cpp_starter_project\build\src\intro.vcxproj]
[build]   catch_main.vcxproj -> C:\lab\cpp_starter_project\build\lib\catch_main.lib
[build]   Building Custom Rule C:/lab/cpp_starter_project/test/CMakeLists.txt
[build]   Building Custom Rule C:/lab/cpp_starter_project/test/CMakeLists.txt
[build]   Building Custom Rule C:/lab/cpp_starter_project/test/CMakeLists.txt
[build]   tests.cpp
[build]   constexpr_tests.cpp
[build]   constexpr_tests.cpp
[build]   constexpr_tests.vcxproj -> C:\lab\cpp_starter_project\build\bin\constexpr_tests.exe
[build]   tests.vcxproj -> C:\lab\cpp_starter_project\build\bin\tests.exe
[build]   relaxed_constexpr_tests.vcxproj -> C:\lab\cpp_starter_project\build\bin\relaxed_constexpr_tests.exe
[build] Build finished with exit code 1
```

And that only needs one line fix. add compile option for utf8

Unlike what I've been doing like [this reference](https://github.com/utilForever/cpp-oss-template/blob/master/CMake/CompileOptions.cmake), I found author of this repo might not want to modify compile options. For that consistency, this request should not be merged.
Still, I wonder if someone else who has the same problem as me will help.


I think following cmake configure log will be enough to explain my environment

``` powershell
[main] Building folder: cpp_starter_project 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build c:/lab/cpp_starter_project/build --config Debug --target ALL_BUILD -- /maxcpucount:14
[build] Microsoft (R) Build Engine version 16.5.0+d4cbfca49 for .NET Framework
[build] Copyright (C) Microsoft Corporation. All rights reserved.
[build] 
[build]   Checking Build System
[build]   Building Custom Rule C:/lab/cpp_starter_project/test/CMakeLists.txt
[build]   Building Custom Rule C:/lab/cpp_starter_project/src/CMakeLists.txt
[build]   catch_main.cpp
[build]   main.cpp
[build] C:\Users\PC\.conan\data\fmt\6.2.0\_\_\package\9ffec4a59d60a2ccf636e06ba57253e21417f01b\include\fmt/core.h(327,35): error C2220: the following warning is treated as an error [C:\lab\cpp_starter_project\build\src\intro.vcxproj]
[build] C:\Users\PC\.conan\data\fmt\6.2.0\_\_\package\9ffec4a59d60a2ccf636e06ba57253e21417f01b\include\fmt/core.h(327,35): warning C4566: character represented by universal-character-name '\u00B5' cannot be represented in the current code page (949) [C:\lab\cpp_starter_project\build\src\intro.vcxproj]
[build] C:\Users\PC\.conan\data\spdlog\1.5.0\_\_\package\cf72f4f3a71ff1fe5381d0f0ebe068c867c28045\include\spdlog/details/circular_q.h(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (949). Save the file in Unicode format to prevent data loss [C:\lab\cpp_starter_project\build\src\intro.vcxproj]
[build]   catch_main.vcxproj -> C:\lab\cpp_starter_project\build\lib\catch_main.lib
[build]   Building Custom Rule C:/lab/cpp_starter_project/test/CMakeLists.txt
[build]   Building Custom Rule C:/lab/cpp_starter_project/test/CMakeLists.txt
[build]   Building Custom Rule C:/lab/cpp_starter_project/test/CMakeLists.txt
[build]   tests.cpp
[build]   constexpr_tests.cpp
[build]   constexpr_tests.cpp
[build]   constexpr_tests.vcxproj -> C:\lab\cpp_starter_project\build\bin\constexpr_tests.exe
[build]   tests.vcxproj -> C:\lab\cpp_starter_project\build\bin\tests.exe
[build]   relaxed_constexpr_tests.vcxproj -> C:\lab\cpp_starter_project\build\bin\relaxed_constexpr_tests.exe
[build] Build finished with exit code 1
```



