### PR TITLE
Don't call non-existent gcov on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ jobs:
         - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - GCC_VER="9"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
-      after_script:
-        - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
     - os: osx
       compiler: clang
       osx_image: xcode11.2


### PR DESCRIPTION
The xcode11.2 MacOS image on Travis does not include a `/usr/bin/gcov-9`
executable, which causes the codecov script to silently fail. I'm not
sure why it doesn't cause the whole build to fail.

This code looks like it works, but it doesn't, and that's a problem.

Even if this code did work, I don't think we really want it, because
we already have a working codecov script running on the Linux gcc build.
I don't think it makes sense to generate a duplicate report.