### PR TITLE
Use python3 virtual environment instead of python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install:
   - python --version | grep -iE 'python\s*3'
   - pip    --version | grep -iE 'python\s*3'
 
+  # venv manages to find pip v9.0, but version 20.2 is current
+  - pip install --upgrade pip
+
   # Install Conan using Python 3.
   - pip install conan cmake
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
 language: cpp
 
 install:
-  - pip install --user conan cmake
+  # Create virtual environment for Python 3
+  - python3 -m venv ~/virtual_env
+  - source ~/virtual_env/bin/activate
+
+  # Fail if we are using the wrong Python
+  - python --version | grep -iE 'python\s*3'
+  - pip    --version | grep -iE 'python\s*3'
+
+  # Install Conan using Python 3.
+  - pip install conan cmake
+
+  # Fail if we can't run Conan.
+  - conan --version
 
 jobs:
   include:
@@ -9,8 +21,6 @@ jobs:
       compiler: gcc
       osx_image: xcode11.2    # includes gcc-9 by default
       env:
-        # Conan is at: ${HOME}/Library/Python/2.7/bin: we need this in the path
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - GCC_VER="9"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
       after_script:
@@ -19,7 +29,6 @@ jobs:
       compiler: clang
       osx_image: xcode11.2
       env:
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - MATRIX_EVAL=""
     - os: linux
       dist: bionic
@@ -37,6 +46,7 @@ jobs:
             - gcc-9
             - g++-9
             - doxygen
+            - python3-venv
       after_script:
         - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
     - os: linux
@@ -44,7 +54,7 @@ jobs:
       compiler: clang
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
-      addons: { apt: { packages: ['doxygen'] } }
+      addons: { apt: { packages: ['doxygen', 'python3-venv'] } }
 
 
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,23 @@
 image:
   - Visual Studio 2019
 clone_folder: c:\projects\source
+
+environment:
+    PYTHON: "C:\\Python38-x64"    # available on VS 2017 and 2019
+
 build_script:
 - cmd: >-
     mkdir build
 
     cd build
 
-    pip install --user conan
+    "%PYTHON%\\python.exe" -m venv virtual_env
+
+    virtual_env\\Scripts\\activate.bat
+
+    python --version
+
+    pip install conan
 
     set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Scripts
 


### PR DESCRIPTION
### Why:
When Conan version 2.0 is released, it will require Python 3 to run. When that happens, this project's CI builds may break when Conan runs using Python 2.

### How:
This uses `venv` to create a virtual environment that will always use Python version 3 whenever `python` or `pip` are run. This solution works the same way on Linux, Mac, and Windows, and it works no matter what version of Python is the default.

### Why remove the `--user` flag:
After venv has been run, all future invocations of `pip` will apply only to the local virtual environment, and not the system as a whole, so the `--user` flag is not allowed.

### Other possible solutions:
* An alternate and much simpler solution would be to use more recent images of Ubuntu and MacOS that use Python 3 as the default version of Python, for instance, Ubuntu 20.04. I am hesitant to recommend this solution because it breaks compatibility with older versions of Ubuntu and Mac.
* Another possibility would be `update-alternatives`, which is a great way to manage different versions of programs on Ubuntu. To my knowledge, it doesn't exist on Mac.
* Travis appears to use `pyenv` to set the desired version of Python for Python projects. I have been unable to get `pyenv` to install the same version of Python on both Linux and Mac without writing a lot of platform-dependent code.
* Use `virtualenv` instead of `venv`. `virtualenv` is preinstalled on both Linux and Mac travis-ci images, so this would eliminate the need to `apt-get install python3-venv` on Linux. This would work, but `virtualenv` is meant for Python 2 package management. The Python docs specifically recommend using `venv` for package management when using Python 3.
* Use `python3 -m pip install <stuff>` instead of using a virtual environment. This approach works just fine, and the code is simpler. You can see what a working example of this would look like on this branch: https://github.com/ddalcino/cpp_starter_project/tree/use_python3. To be honest, I think this may be a better approach than using a venv. I will update this comment if I can think of any real disadvantage to this approach in a CI environment.

Edit on Sept 7 to add `python -m pip install` alternate approach