### PR TITLE
Use python3 instead of python2 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: cpp
 
 install:
-  - pip install --user conan cmake
+  # Pip cannot install Conan without these upgrades
+  - python3 -m pip install --upgrade pip setuptools
+  # Install Conan and CMake >= 3.15
+  - python3 -m pip install --user conan cmake
+
+  # Fail if we can't run Conan.
+  - conan --version
 
 jobs:
   include:
@@ -9,8 +15,6 @@ jobs:
       compiler: gcc
       osx_image: xcode11.2    # includes gcc-9 by default
       env:
-        # Conan is at: ${HOME}/Library/Python/2.7/bin: we need this in the path
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - GCC_VER="9"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
       after_script:
@@ -19,7 +23,6 @@ jobs:
       compiler: clang
       osx_image: xcode11.2
       env:
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - MATRIX_EVAL=""
     - os: linux
       dist: bionic
@@ -37,6 +40,7 @@ jobs:
             - gcc-9
             - g++-9
             - doxygen
+            - python3-pip
       after_script:
         - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
     - os: linux
@@ -44,7 +48,7 @@ jobs:
       compiler: clang
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
-      addons: { apt: { packages: ['doxygen'] } }
+      addons: { apt: { packages: ['doxygen', 'python3-pip'] } }
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install:
   # Pip cannot install Conan without these upgrades
   - python3 -m pip install --upgrade pip setuptools
   # Install Conan and CMake >= 3.15
-  - python3 -m pip install --user conan cmake
+  - python3 -m pip install conan cmake
 
   # Fail if we can't run Conan.
   - conan --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ build_script:
 
     cd build
 
-    "%PYTHON%" -m pip install --user conan
+    set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Python38\Scripts
 
-    set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Scripts
+    "%PYTHON%" -m pip install --user conan
 
     cmake c:\projects\source -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE:STRING=Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,17 @@
 image:
   - Visual Studio 2019
 clone_folder: c:\projects\source
+
+environment:
+    PYTHON: "C:\\Python38-x64\\python.exe"
+
 build_script:
 - cmd: >-
     mkdir build
 
     cd build
 
-    pip install --user conan
+    "%PYTHON%" -m pip install --user conan
 
     set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Scripts
 


### PR DESCRIPTION
### Why:

When Conan version 2.0 is released, it will require Python 3 to run. When that happens, this project's CI builds may break when Conan runs using Python 2.

### How:

This calls `python3` directly to install Conan globally; this ensures that Conan is available to CMake, and it will always be run with Python 3. 

### Other possible solutions:

* An alternate and much simpler solution would be to use more recent images of Ubuntu and MacOS that use Python 3 as the default version of Python, for instance, Ubuntu 20.04. I am hesitant to recommend this solution because it breaks compatibility with older versions of Ubuntu and Mac.
* Another possibility would be update-alternatives, which is a great way to manage different versions of programs on Ubuntu. To my knowledge, it doesn't exist on Mac.
* Travis appears to use pyenv to set the desired version of Python for Python projects. I have been unable to get pyenv to install the same version of Python on both Linux and Mac without writing a lot of platform-dependent code.
* Use a virtual environment instead. See #86 for an example of this. Offers no tangible benefit compared to this PR, and might run slower in CI.