### PR TITLE
Fixed -ftime-trace option registration command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ target_compile_features(project_options INTERFACE cxx_std_17)
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
   option(ENABLE_BUILD_WITH_TIME_TRACE "Enable -ftime-trace to generate time tracing .json files on clang" OFF)
   if(ENABLE_BUILD_WITH_TIME_TRACE)
-    add_compile_definitions(project_options INTERFACE -ftime-trace)
+    target_compile_options(project_options INTERFACE -ftime-trace)
   endif()
 endif()
 


### PR DESCRIPTION
Hello,

I've been playing around a bit with your `cpp_starter_project` and I think I found an issue with how the `-ftime-trace` option is being registered into the project. It seems I've also find a solution, but could you please take a look at it as I'm fairly new to CMake. Thanks in advance.

Cheers,

PETR
