### PR TITLE
Update multiple Conan dependencies.

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -16,10 +16,10 @@ macro(run_conan)
   conan_cmake_run(
     REQUIRES
     ${CONAN_EXTRA_REQUIRES}
-    catch2/2.13.1
+    catch2/2.13.4
     docopt.cpp/0.6.3
-    fmt/7.0.3
-    spdlog/1.8.0
+    fmt/7.1.3
+    spdlog/1.8.2
     OPTIONS
     ${CONAN_EXTRA_OPTIONS}
     BASIC_SETUP

--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -16,10 +16,10 @@ macro(run_conan)
   conan_cmake_run(
     REQUIRES
     ${CONAN_EXTRA_REQUIRES}
-    catch2/2.11.0
-    docopt.cpp/0.6.2
-    fmt/6.2.0
-    spdlog/1.5.0
+    catch2/2.13.1
+    docopt.cpp/0.6.3
+    fmt/7.0.3
+    spdlog/1.8.0
     OPTIONS
     ${CONAN_EXTRA_OPTIONS}
     BASIC_SETUP


### PR DESCRIPTION
The `fmt` update is meant to address a bug reported in #81.

Note that `spdlog/1.8.0` is dependent on `fmt/7.0.3`.

Related to #65: specific dependency versions supersede #65, but this does not replace the move to a separate file. Unless these dependencies are moved to a separate file, the process of bumping these dependencies cannot be easily automated, and PRs like this one will always be necessary to keep packages up to date.