### PR TITLE
Fix CMakeLists.txt on src/fltk and src/gtkmm

### DIFF
--- a/src/fltk/CMakeLists.txt
+++ b/src/fltk/CMakeLists.txt
@@ -1,4 +1,4 @@
 find_package(FLTK REQUIRED)
-add_executable(test_fltk fltk/test_fltk.cpp)
+add_executable(test_fltk test_fltk.cpp)
 target_link_libraries(test_fltk PRIVATE project_warnings project_options ${FLTK_LIBRARIES})
 target_include_directories(test_fltk PRIVATE ${FLTK_INCLUDE_DIR})

--- a/src/gtkmm/CMakeLists.txt
+++ b/src/gtkmm/CMakeLists.txt
@@ -4,5 +4,5 @@ pkg_check_modules(
   REQUIRED
   IMPORTED_TARGET
   gtkmm-3.0)
-add_executable(test_gtkmm gtkmm/main.cpp gtkmm/hello_world.cpp)
+add_executable(test_gtkmm main.cpp hello_world.cpp)
 target_link_libraries(test_gtkmm PRIVATE project_warnings project_options PkgConfig::GTKMM)


### PR DESCRIPTION
Removed the folder prefix in the add_executable cmake command in src/fltk/CMakeLists.txt and src/gtkmm/CMakeLists.txt to fix the following error that occures during CMake Generation:

`CMake Error at src/fltk/CMakeLists.txt:2 (add_executable):
   Cannot find source file:

     fltk/test_fltk.cpp

   Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
   .hpp .hxx .in .txx

 CMake Error at src/gtkmm/CMakeLists.txt:7 (add_executable):
   Cannot find source file:

     gtkmm/main.cpp

   Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
   .hpp .hxx .in .txx

 CMake Error at src/fltk/CMakeLists.txt:2 (add_executable):
   No SOURCES given to target: test_fltk

 CMake Error at src/gtkmm/CMakeLists.txt:7 (add_executable):
   No SOURCES given to target: test_gtkmm
`
