### PR TITLE
Add conan-center repo to be able to find missing packages (e.g. catch2)

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -9,6 +9,12 @@ macro(run_conan)
 
   conan_add_remote(
     NAME
+    conan-center
+    URL
+    https://api.bintray.com/conan/conan/conan-center)
+
+  conan_add_remote(
+    NAME
     bincrafters
     URL
     https://api.bintray.com/conan/bincrafters/public-conan)


### PR DESCRIPTION
Trying to build the the project from scratch (on my Windows machine with VS2019 open folder functionality) it failed to download catch2/2/11/0. After a bit of search I realized that this version of catch2 is on conan-center repo and I didn't added that one before. Conan.cmake should add all necessary conan repos you need.

P.S. there is a new catch2/2/13.3 version but I am not sure how regularly this template project should update the third party libraries.