### PR TITLE
Disable llvmlibc-callee-namespace warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm-*'
+Checks:          '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm*'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle:     none


### PR DESCRIPTION
Disable llvmlibc-callee-namespace warnings. This case was not covered due to the second dash.