### PR TITLE
Remove duplicate header in template source file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,11 +2,7 @@
 #include <iostream>
 
 #include <spdlog/spdlog.h>
-
-
 #include <docopt/docopt.h>
-
-#include <iostream>
 
 static constexpr auto USAGE =
   R"(Naval Fate.


### PR DESCRIPTION
Removes the duplicate "#include \<iostream\>". Unless this is for demonstrating warnings/static analysis. Though the default static analysis tools didn't pick it up.