### PR TITLE
Suppress max/min macros in windows.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
   endif()
 endif()
 
+if(MSVC)
+  # Prevent definition of `min` and `max` macros included by `windows.h`
+  target_compile_definitions(project_options INTERFACE NOMINMAX)
+endif()
+
 # Link this 'library' to use the warnings specified in CompilerWarnings.cmake
 add_library(project_warnings INTERFACE)
 


### PR DESCRIPTION
Using MS Visual Studio, when you `#include <windows.h>`, some preprocessor macros are defined by default for `min()` and `max()`. As a result, `windows.h` interferes with the C++ STL, for example, `std::numeric_limits::min()` and `std::max()` in the algorithm header.

See [`minwindef.h`](https://github.com/tpn/winsdk-10/blob/master/Include/10.0.16299.0/shared/minwindef.h#LC190) for the offending code. This header is included by [`windef.h`](https://github.com/tpn/winsdk-10/blob/master/Include/10.0.16299.0/shared/windef.h#LC24), which is included by [`windows.h`](https://github.com/tpn/winsdk-10/blob/master/Include/10.0.16299.0/um/Windows.h#LC171). Thankfully, these definitions of `min` and `max` are surrounded by an `#ifndef NOMINMAX`, so we have a ready solution to the problem.

**Alternatives:** You could just not ever use the Visual Studio compiler; the `windows.h` file that ships with my MSys2 mingw-gcc does not have this problem. You could use some preprocessor #defines and/or #undefs in your otherwise pristine ISO-compliant C++ code. I prefer to use good cmake defaults that prevent this kind of thing from ever showing up. You shouldn't ever have to think about weird stuff like this.

**Potential for improvement:** I think that it might be worth moving this kind of code to a separate file in the cmake folder, perhaps called `cmake/Definitions.cmake`, but I'm not sure that's necessary.

**Background:** I just ran into this conflict between `windows.h` and `std::numeric_limits` in another project. When I googled the two terms together, I was so mad that so many other people complaining about this problem that I had to do something. Please, let's have sane defaults that make it easier to use the C++ STL, and not clobber the std namespace with legacy preprocessor macros!