### PR TITLE
Fix Conan warning for spdlog dependency

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -18,7 +18,7 @@ macro(run_conan)
     ${CONAN_EXTRA_REQUIRES}
     catch2/2.13.3
     docopt.cpp/0.6.2
-    fmt/6.2.0
+    fmt/6.2.1
     spdlog/1.5.0
     OPTIONS
     ${CONAN_EXTRA_OPTIONS}


### PR DESCRIPTION
At some point, spdlog 1.5.0 changed its dependencies to require fmt 6.2.1, rather than 6.2.0. As a result, every time you configure the project, you see this warning:

    WARN: spdlog/1.5.0: requirement fmt/6.2.1 overridden by your conanfile to fmt/6.2.0

This commit fixes that warning, and prevents whatever latent bugs the spdlog devs expect this version mismatch to cause.

Note that the current version of spdlog (1.8.2) requires fmt version 7.1.3; it would make a lot of sense to update the versions of both packages.