### PR TITLE
Add cmake helpers to cmake module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,12 @@ cmake_minimum_required(VERSION 3.15)
 
 # Set the project name to your project name, my project isn't very descriptive
 project(myproject CXX)
-include(cmake/StandardProjectSettings.cmake)
-include(cmake/PreventInSourceBuilds.cmake)
+
+# Add cmake helpers to cmake module path
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
+include(StandardProjectSettings)
+include(PreventInSourceBuilds)
 
 # Link this 'library' to set the c++ standard / compile-time options requested
 add_library(project_options INTERFACE)
@@ -20,22 +24,22 @@ endif()
 add_library(project_warnings INTERFACE)
 
 # enable cache system
-include(cmake/Cache.cmake)
+include(Cache)
 
 # standard compiler warnings
-include(cmake/CompilerWarnings.cmake)
+include(CompilerWarnings)
 set_project_warnings(project_warnings)
 
 # sanitizer options if supported by compiler
-include(cmake/Sanitizers.cmake)
+include(Sanitizers)
 enable_sanitizers(project_options)
 
 # enable doxygen
-include(cmake/Doxygen.cmake)
+include(Doxygen)
 enable_doxygen()
 
 # allow for static analysis options
-include(cmake/StaticAnalyzers.cmake)
+include(StaticAnalyzers)
 
 option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" OFF)
 option(ENABLE_TESTING "Enable Test Builds" ON)
@@ -72,7 +76,7 @@ if(CPP_STARTER_USE_SDL)
   # set(CONAN_EXTRA_OPTIONS ${CONAN_EXTRA_OPTIONS} sdl2:wayland=True)
 endif()
 
-include(cmake/Conan.cmake)
+include(Conan)
 run_conan()
 
 if(ENABLE_TESTING)


### PR DESCRIPTION
Overall this is more of a just Quality of Life improvement as it just removes visual cruft when including each CMake helper