### PR TITLE
docopt default output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, const char **argv)
     "Naval Fate 2.0");// version string
 
   for (auto const &arg : args) {
-    std::cout << arg.first << arg.second << std::endl;
+    std::cout << arg.first << "=" << arg.second << std::endl;
   }
 
 


### PR DESCRIPTION
I had no prior experience with docopt, the default output would have been more clear by expressing the pair as key=value rather than keyvalue.