### PR TITLE
Use cmake -S and -B parameters in github action

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -49,14 +49,10 @@ jobs:
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      #
       # We need to source the profile file to make sure conan is in PATH
       run: |
         source ~/.profile
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        cmake -S $GITHUB_WORKSPACE -B . -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
When reviewing the github action for a project based on the template I noticed that all github platforms now provice cmake > 3.12, so we can replace the comment advocating -S and -B and just use it \o/. I only later noticed that the template only builds on linux, thats why I also included the versions for the other platforms for which we build.

Cmake versions at this time on the different platforms:
CMake 3.19.7 (ubuntu-latest [1])
Cmake 3.19.6 (macos-latest [2])
CMake 3.19.7 (windows-latest [3])

[1] https://github.com/actions/virtual-environments/blob/ubuntu20/20210318.0/images/linux/Ubuntu2004-README.md#tools
[2] https://github.com/actions/virtual-environments/blob/macOS-10.15/20210314.1/images/macos/macos-10.15-Readme.md#tools
[3] https://github.com/actions/virtual-environments/blob/win19/20210316.1/images/win/Windows2019-Readme.md#tools