### PR TITLE
Add config and badge for lgtm vulnerability analysis tool

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,24 @@
+# for full syntax documentation see:  https://lgtm.com/help/lgtm/lgtm.yml-configuration-file
+path_classifiers:
+  test:
+    - "*/fuzz_test/**/*"
+    - "*/test/**/*"
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - g++-10
+        - ccache
+      script:
+        - mkdir ~/.conan
+        - cat /usr/local/share/ca-certificates/semmle-cache-ca/semmle-cache-ca.crt >> ~/.conan/cacert.pem
+        - python3 -m pip install --upgrade pip setuptools
+        - python3 -m pip install conan
+        - python3 -m pip install cmake
+        - source ~/.profile
+    configure:
+      command:
+        - mkdir build
+        - cmake -D ENABLE_COVERAGE:BOOL=TRUE -S . -B build
+    index:
+      build_command: cmake --build ./build -- -j2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ![CMake](https://github.com/lefticus/cpp_starter_project/workflows/CMake/badge.svg)
 
+[![Language grade: C++](https://img.shields.io/lgtm/grade/cpp/github/lefticus/cpp_starter_project)](https://lgtm.com/projects/g/lefticus/cpp_starter_project/context:cpp)
 
 ## Getting Started
 

--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -2,23 +2,25 @@ macro(run_conan)
   # Download automatically, you can also just copy the conan.cmake file
   if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
     message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.15/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake")
+    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.16.1/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake")
   endif()
 
   include(${CMAKE_BINARY_DIR}/conan.cmake)
 
   conan_add_remote(
-    NAME
-    bincrafters
-    URL
-    https://api.bintray.com/conan/bincrafters/public-conan)
+    NAME conan-center
+    URL https://api.bintray.com/conan/conan/conan-center)
+
+  conan_add_remote(
+    NAME bincrafters
+    URL https://api.bintray.com/conan/bincrafters/public-conan)
 
   conan_cmake_run(
     REQUIRES
     ${CONAN_EXTRA_REQUIRES}
     catch2/2.13.3
     docopt.cpp/0.6.2
-    fmt/6.2.0
+    fmt/6.2.1
     spdlog/1.5.0
     OPTIONS
     ${CONAN_EXTRA_OPTIONS}


### PR DESCRIPTION
The [lgtm](https://lgtm.com/) vulnerability analysis tool does not work with out-of-tree builds without a custom extraction config. This PR proposal adds the required config and badge.

N.B. the badge status will only show-up after being merged. For illustration, you may consult [this](https://github.com/fair-acc/opencmw-cpp) as an example). In addition, we also added the missing conan-center repository (needed for catch2), bumped the conan-cmake plugin and fmt version number (both caused needles conflict/warning messages).

Thanks also to my fellow co-conspirator @wirew0rm.