### PR TITLE
Fix compilation failure for Nana example

### DIFF
--- a/src/nana/CMakeLists.txt
+++ b/src/nana/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(
 # ExternalProject_Get_Property(Nana NANA_INCLUDE_DIR)
 ExternalProject_Get_Property(Nana SOURCE_DIR BINARY_DIR)
 add_executable(test_nana main.cpp)
-target_include_directories(test_nana PRIVATE ${SOURCE_DIR}/include)
+target_include_directories(test_nana SYSTEM PRIVATE ${SOURCE_DIR}/include)
 add_dependencies(test_nana Nana)
 target_link_libraries(
   test_nana


### PR DESCRIPTION
# What:
Currently, the Nana example does not compile when `WARNINGS_AS_ERRORS` is turned on. This is because there are shadowed variable names in the Nana header file, which triggers the `-Wshadow` warning. This change convinces the compiler not to trigger warnings on any of the Nana headers. With this fix applied, you don't get errors from the Nana headers, but you still get the benefits of `WARNINGS_AS_ERRORS` in your own code.

# How:
This change adds the `SYSTEM` keyword to the `target_include_directories` call that adds the Nana headers. This will convince the compiler that the Nana headers are system headers, and should not be affected by warnings. 

See `target_include_directories` docs at: https://cmake.org/cmake/help/v3.0/command/target_include_directories.html