### PR TITLE
Update Conan.cmake to v0.16.1

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -2,7 +2,10 @@ macro(run_conan)
   # Download automatically, you can also just copy the conan.cmake file
   if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
     message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.15/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake")
+    file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
+      "${CMAKE_BINARY_DIR}/conan.cmake"
+      EXPECTED_HASH SHA256=396e16d0f5eabdc6a14afddbcfff62a54a7ee75c6da23f32f7a31bc85db23484
+      TLS_VERIFY ON)
   endif()
 
   include(${CMAKE_BINARY_DIR}/conan.cmake)


### PR DESCRIPTION
Release notes since v0.15:
- [v0.16.0](https://github.com/conan-io/cmake-conan/releases/tag/v0.16)
- [v0.16.1](https://github.com/conan-io/cmake-conan/releases/tag/v0.16.1)

Also chage snippet according to conan cmake's [README](https://github.com/conan-io/cmake-conan/blob/develop/README.md).
Main differences:
 - directly link to github's cdn
 - enable verification of the TLS connection and the file hash.

fixes: #135