### PR TITLE
Add `-Wimplicit-fallthrough` to Clang warnings

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -47,6 +47,7 @@ function(set_project_warnings project_name)
       -Wnull-dereference # warn if a null dereference is detected
       -Wdouble-promotion # warn if float is implicit promoted to double
       -Wformat=2 # warn on security issues around functions that format output (ie printf)
+      -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation
   )
 
   if(WARNINGS_AS_ERRORS)


### PR DESCRIPTION
Clang doesn't enable this warning by default neither in `-Wall` nor `-Wextra`.