### PR TITLE
Update Conan.cmake for migrated bincrafters repo

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -11,7 +11,7 @@ macro(run_conan)
     NAME
     bincrafters
     URL
-    https://api.bintray.com/conan/bincrafters/public-conan)
+    https://bincrafters.jfrog.io/artifactory/api/conan/public-conan)
 
   conan_cmake_run(
     REQUIRES


### PR DESCRIPTION
Bintray services are sunsetting on May 1st, 2021: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Bincrafters repo has migrated to jfrog.io. Endpoint instructions are here: https://bincrafters.readthedocs.io/en/latest/using_packages.html#adding-the-bincrafters-repository-as-a-conan-remote