### PR TITLE
disable clang-tidy failure on recursive function

### DIFF
--- a/test/constexpr_tests.cpp
+++ b/test/constexpr_tests.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch.hpp>
 
-constexpr unsigned int Factorial(unsigned int number)
+constexpr unsigned int Factorial(unsigned int number)// NOLINT(misc-no-recursion)
 {
   return number <= 1 ? number : Factorial(number - 1) * number;
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch.hpp>
 
-unsigned int Factorial(unsigned int number)
+unsigned int Factorial(unsigned int number)// NOLINT(misc-no-recursion)
 {
   return number <= 1 ? number : Factorial(number - 1) * number;
 }


### PR DESCRIPTION
- Factorial is explicitly implemented recursively, so we'll have to
explicitly disable the check for recursive function calls here

(failure found with clang-tidy-12)