### PR TITLE
use ON/OFF consistently for CMake options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
 script:
   - mkdir build
   - cd build
-  - cmake -D ENABLE_COVERAGE:BOOL=TRUE ../
+  - cmake -D ENABLE_COVERAGE:BOOL=ON ../
   - cmake --build . -- -j2
   - ctest -j2
 

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -3,7 +3,7 @@
 # https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
 
 function(set_project_warnings project_name)
-  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
+  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 
   set(MSVC_WARNINGS
       /W4 # Baseline reasonable warnings

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,7 +1,7 @@
 function(enable_sanitizers project_name)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-    option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
+    option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" OFF)
 
     if(ENABLE_COVERAGE)
       target_compile_options(${project_name} INTERFACE --coverage -O0 -g)
@@ -10,22 +10,22 @@ function(enable_sanitizers project_name)
 
     set(SANITIZERS "")
 
-    option(ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" FALSE)
+    option(ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" OFF)
     if(ENABLE_SANITIZER_ADDRESS)
       list(APPEND SANITIZERS "address")
     endif()
 
-    option(ENABLE_SANITIZER_LEAK "Enable leak sanitizer" FALSE)
+    option(ENABLE_SANITIZER_LEAK "Enable leak sanitizer" OFF)
     if(ENABLE_SANITIZER_LEAK)
       list(APPEND SANITIZERS "leak")
     endif()
 
-    option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR "Enable undefined behavior sanitizer" FALSE)
+    option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR "Enable undefined behavior sanitizer" OFF)
     if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
       list(APPEND SANITIZERS "undefined")
     endif()
 
-    option(ENABLE_SANITIZER_THREAD "Enable thread sanitizer" FALSE)
+    option(ENABLE_SANITIZER_THREAD "Enable thread sanitizer" OFF)
     if(ENABLE_SANITIZER_THREAD)
       if("address" IN_LIST SANITIZERS OR "leak" IN_LIST SANITIZERS)
         message(WARNING "Thread sanitizer does not work with Address and Leak sanitizer enabled")
@@ -34,7 +34,7 @@ function(enable_sanitizers project_name)
       endif()
     endif()
 
-    option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" FALSE)
+    option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" OFF)
     if(ENABLE_SANITIZER_MEMORY AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
       if("address" IN_LIST SANITIZERS
          OR "thread" IN_LIST SANITIZERS

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -27,7 +27,7 @@ if(ENABLE_IPO)
     OUTPUT
     output)
   if(result)
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
   else()
     message(SEND_ERROR "IPO is not supported: ${output}")
   endif()


### PR DESCRIPTION
while CMake options are mostly syntactic sugar for cached boolean
variables which support both ON/OFF and TRUE/FALSE, they are documented
with ON/OFF exclusively (https://cmake.org/cmake/help/latest/command/option.html).
ON/OFF were also used elsewhere in the project, so this commit makes the
use consistent throughout the project.