### PR TITLE
Updated bincrafters' remote link and using conan package revisions 

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -12,7 +12,7 @@ macro(run_conan)
     NAME
     bincrafters
     URL
-    https://bincrafters.jfrog.io/artifactory/api/conan/public-conan
+    https://bincrafters.jfrog.io/artifactory/api/conan/public-conan)
 
   conan_cmake_run(
     REQUIRES

--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -5,13 +5,14 @@ macro(run_conan)
     file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.15/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake")
   endif()
 
+  set (ENV{CONAN_REVISIONS_ENABLED} 1)
   include(${CMAKE_BINARY_DIR}/conan.cmake)
 
   conan_add_remote(
     NAME
     bincrafters
     URL
-    https://api.bintray.com/conan/bincrafters/public-conan)
+    https://bincrafters.jfrog.io/artifactory/api/conan/public-conan
 
   conan_cmake_run(
     REQUIRES


### PR DESCRIPTION
This PR is a partial duplicate of (now closed) #139. Thank you to @arvidsaur for their initial PR.
## Reasons for the change 

* The old bincrafters remote was shutdown on 2021-05-01, as described in [this](https://bincrafters.github.io/2020/04/19/infrastructure-changes-and-required-actions/) post. 
* All packages were moved to a new remote, link to which I added to `cmake/Conan.cmake`. 
* The new remote requires Conan's [package revisions](https://docs.conan.io/en/latest/versioning/revisions.html) to be on, best way of doing this (that I found),without requiring users to change their global `conan.conf` is  by setting the environment variable `CONAN_REVISIONS_ENABLED=1` with cmake.

Edit: Added missing closing bracket..