### PR TITLE
warn about need for instrumented libs with MSan when using clang

### DIFF
--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -36,6 +36,7 @@ function(enable_sanitizers project_name)
 
     option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" FALSE)
     if(ENABLE_SANITIZER_MEMORY AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+      message(WARNING "Memory sanitizer reports false positives when running against libraries that are not MSan-instrumented (including libc++)")
       if("address" IN_LIST SANITIZERS
          OR "thread" IN_LIST SANITIZERS
          OR "leak" IN_LIST SANITIZERS)

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -36,7 +36,7 @@ function(enable_sanitizers project_name)
 
     option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" FALSE)
     if(ENABLE_SANITIZER_MEMORY AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-      message(WARNING "Memory sanitizer reports false positives when running against libraries that are not MSan-instrumented (including libc++)")
+      message(WARNING "Memory sanitizer requires all the code (including libc++) to be MSan-instrumented otherwise it reports false positives")
       if("address" IN_LIST SANITIZERS
          OR "thread" IN_LIST SANITIZERS
          OR "leak" IN_LIST SANITIZERS)


### PR DESCRIPTION
when clang is invoked with -fsanitize=memory, all libraries, including the standard library has to be built with that instrumentation to avoid false positives. This PR emits a warning for that case, so people do not have to google for the reason for failing CMake builds

https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo