### PR TITLE
Allow users to turn off Conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,11 @@ if(ENABLE_PCH)
     <utility>)
 endif()
 
-include(cmake/Conan.cmake)
-run_conan()
+option(ENABLE_CONAN "Use Conan for dependency management" ON)
+if(ENABLE_CONAN)
+  include(cmake/Conan.cmake)
+  run_conan()
+endif()
 
 if(ENABLE_TESTING)
   enable_testing()


### PR DESCRIPTION
This PR allows users to opt out of using Conan for dependency management. It can be very challenging to get Conan to successfully build some dependencies (that means you, SDL2!), and I think there's some value in allowing users to turn Conan on and off at will, if they think it will be easier to satisfy those dependencies in some other way.

This change depends on some changes made by #150; currently, `src/CMakeLists.txt` depends directly on the use of Conan to satisfy package management, but #150 will separate the build system from Conan enough that the dependencies can be fulfilled in some other way.

I would like to request that this PR not be merged until after #150 is merged.